### PR TITLE
Add forensic output detail level

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -25,7 +25,8 @@
       "Bash(curl:*)",
       "Bash(git checkout:*)",
       "Bash(git merge:*)",
-      "WebFetch(domain:localhost)"
+      "WebFetch(domain:localhost)",
+      "Bash(git branch:*)"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Adds **Forensic** as the fourth output detail level, providing maximum debugging context for layout and style issues.

### What's included in Forensic mode

**Environment section:**
- Viewport dimensions
- Full URL
- User Agent string
- Timestamp (ISO format)
- Device Pixel Ratio

**Per-annotation data:**
- Full DOM Path (complete ancestry from body)
- CSS Classes
- Position (bounding box coordinates and dimensions)
- Annotation coordinates (% from left, px from top)
- Computed Styles (relevant CSS properties)
- Accessibility info (role, aria attributes, focusability)
- Nearby Elements (sibling context)

### Multi-select annotations

For drag-select annotations that capture multiple elements, forensic data is captured from the **first selected element** only. The output includes an italicized note: *"Forensic data shown for first element of selection"*

This approach balances providing useful debugging context without overwhelming the output when many elements are selected.

### Output order

The forensic output order now matches the example shown on the `/output` documentation page.

## Test plan

- [ ] Verify forensic option appears in toolbar settings cycle
- [ ] Create single-element annotation and check forensic output includes all fields
- [ ] Create multi-select annotation and verify first-element forensic data with note
- [ ] Compare output format against `/output` page example

---

@tofuness - Would appreciate your review on this, particularly the multi-select approach. Let me know if you'd prefer a different strategy (e.g., skip forensic for multi-select, or aggregate data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)