### PR TITLE
fix: remove misleading optional flag for framer-motion peer dependency

### DIFF
--- a/_package-export/package.json
+++ b/_package-export/package.json
@@ -26,11 +26,6 @@
     "react-dom": ">=18.0.0",
     "framer-motion": ">=10.0.0"
   },
-  "peerDependenciesMeta": {
-    "framer-motion": {
-      "optional": true
-    }
-  },
   "devDependencies": {
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",


### PR DESCRIPTION
## Summary

Fixes #17

Removes the misleading `optional: true` flag from `framer-motion` in `peerDependenciesMeta`.

## Problem

`framer-motion` is imported unconditionally in the source code, so it's not truly optional. Marking it as optional causes package managers to skip auto-installing it, leading to runtime errors:

```
Module not found: Can't resolve 'framer-motion'
```

## Solution

Remove the `peerDependenciesMeta` section for `framer-motion` so it's properly recognized as a required peer dependency.

## Changes

- `_package-export/package.json`: Removed `peerDependenciesMeta` block