### PR TITLE
Fix Enter key submission during IME composition

### DIFF
--- a/_package-export/src/components/annotation-popup-css/index.tsx
+++ b/_package-export/src/components/annotation-popup-css/index.tsx
@@ -143,7 +143,8 @@ export const AnnotationPopupCSS = forwardRef<AnnotationPopupCSSHandle, Annotatio
 
     // Handle keyboard
     const handleKeyDown = useCallback(
-      (e: React.KeyboardEvent) => {
+      (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        if (e.nativeEvent.isComposing) return;
         if (e.key === "Enter" && !e.shiftKey) {
           e.preventDefault();
           handleSubmit();


### PR DESCRIPTION
# Summary

This PR fixes an issue where pressing Enter during IME composition could unintentionally submit the textarea input.
It improves text input handling for users using IME (e.g. Japanese, Chinese, Korean) without affecting existing keyboard shortcuts.

# What it does
Prevents Enter key submission or Escape key cancel while IME composition is active.
React.KeyboardEvent does not seem to expose isComposing, so that I switches IME detection from React.KeyboardEvent.isComposing to nativeEvent.isComposing.

