### PR TITLE
feat: Add position prop for toolbar placement

### DIFF
--- a/_package-export/src/components/page-toolbar-css/index.tsx
+++ b/_package-export/src/components/page-toolbar-css/index.tsx
@@ -245,6 +245,9 @@ export type DemoAnnotation = {
   selectedText?: string;
 };
 
+/** Position of the toolbar on the screen. */
+export type ToolbarPosition = 'bottom-right' | 'bottom-left' | 'top-right' | 'top-left';
+
 export type PageFeedbackToolbarCSSProps = {
   demoAnnotations?: DemoAnnotation[];
   demoDelay?: number;
@@ -261,6 +264,8 @@ export type PageFeedbackToolbarCSSProps = {
   onCopy?: (markdown: string) => void;
   /** Whether to copy to clipboard when the copy button is clicked. Defaults to true. */
   copyToClipboard?: boolean;
+  /** Position of the toolbar on the screen. Defaults to 'bottom-right'. */
+  position?: ToolbarPosition;
 };
 
 /** Alias for PageFeedbackToolbarCSSProps */
@@ -280,6 +285,7 @@ export function PageFeedbackToolbarCSS({
   onAnnotationsClear,
   onCopy,
   copyToClipboard = true,
+  position = 'bottom-right',
 }: PageFeedbackToolbarCSSProps = {}) {
   const [isActive, setIsActive] = useState(false);
   const [annotations, setAnnotations] = useState<Annotation[]>([]);
@@ -1654,7 +1660,7 @@ export function PageFeedbackToolbarCSS({
     <>
       {/* Toolbar */}
       <div
-        className={styles.toolbar}
+        className={`${styles.toolbar} ${position === 'bottom-left' ? styles.bottomLeft : ''} ${position === 'top-right' ? styles.topRight : ''} ${position === 'top-left' ? styles.topLeft : ''}`}
         data-feedback-toolbar
         style={
           toolbarPosition
@@ -1669,7 +1675,7 @@ export function PageFeedbackToolbarCSS({
       >
         {/* Morphing container */}
         <div
-          className={`${styles.toolbarContainer} ${!isDarkMode ? styles.light : ""} ${isActive ? styles.expanded : styles.collapsed} ${showEntranceAnimation ? styles.entrance : ""} ${isDraggingToolbar ? styles.dragging : ""}`}
+          className={`${styles.toolbarContainer} ${!isDarkMode ? styles.light : ""} ${isActive ? styles.expanded : styles.collapsed} ${showEntranceAnimation ? styles.entrance : ""} ${isDraggingToolbar ? styles.dragging : ""} ${(position === 'bottom-left' || position === 'top-left') ? styles.alignLeft : ''}`}
           onClick={
             !isActive
               ? (e) => {
@@ -1835,7 +1841,7 @@ export function PageFeedbackToolbarCSS({
 
           {/* Settings Panel */}
           <div
-            className={`${styles.settingsPanel} ${isDarkMode ? styles.dark : styles.light} ${showSettingsVisible ? styles.enter : styles.exit}`}
+            className={`${styles.settingsPanel} ${isDarkMode ? styles.dark : styles.light} ${showSettingsVisible ? styles.enter : styles.exit} ${(position === 'bottom-left' || position === 'top-left') ? styles.alignLeft : ''} ${(position === 'top-right' || position === 'top-left') ? styles.alignTop : ''}`}
             onClick={(e) => e.stopPropagation()}
             style={
               toolbarPosition && toolbarPosition.y < 230

--- a/_package-export/src/components/page-toolbar-css/styles.module.scss
+++ b/_package-export/src/components/page-toolbar-css/styles.module.scss
@@ -199,6 +199,24 @@ $green: #34c759;
         top 0s,
         right 0s,
         bottom 0s; // Instant positioning changes
+
+    // Position variants
+    &.bottomLeft {
+        right: unset;
+        left: 1.25rem;
+    }
+
+    &.topRight {
+        bottom: unset;
+        top: 1.25rem;
+    }
+
+    &.topLeft {
+        right: unset;
+        left: 1.25rem;
+        bottom: unset;
+        top: 1.25rem;
+    }
 }
 
 .toolbarContainer {
@@ -216,6 +234,13 @@ $green: #34c759;
         0 4px 16px rgba(0, 0, 0, 0.1);
     pointer-events: auto;
     cursor: grab;
+
+    // Left-aligned position variant
+    &.alignLeft {
+        margin-left: 0;
+        margin-right: auto;
+        align-self: flex-start;
+    }
 
     // Animated properties
     transition:
@@ -839,6 +864,18 @@ $green: #34c759;
     transition:
         background 0.25s ease,
         box-shadow 0.25s ease;
+
+    // Left-aligned position variant
+    &.alignLeft {
+        right: unset;
+        left: 5px;
+    }
+
+    // Top position variant (panel opens below toolbar)
+    &.alignTop {
+        bottom: unset;
+        top: calc(100% + 0.5rem);
+    }
 
     // Transition for all child elements
     .settingsHeader,

--- a/_package-export/src/index.ts
+++ b/_package-export/src/index.ts
@@ -15,7 +15,7 @@
 // CSS-only version (default - zero runtime deps)
 export { PageFeedbackToolbarCSS as Agentation } from "./components/page-toolbar-css";
 export { PageFeedbackToolbarCSS } from "./components/page-toolbar-css";
-export type { DemoAnnotation, AgentationProps } from "./components/page-toolbar-css";
+export type { DemoAnnotation, AgentationProps, ToolbarPosition } from "./components/page-toolbar-css";
 
 // Shared components (for building custom UIs)
 export { AnnotationPopupCSS } from "./components/annotation-popup-css";


### PR DESCRIPTION
## Summary

Adds a new `position` prop to customize toolbar placement on the screen:

- `'bottom-right'` (default, current behavior)
- `'bottom-left'`
- `'top-right'`
- `'top-left'`

## Usage

```tsx
// Default (bottom-right)
<Agentation />

// Bottom-left corner
<Agentation position="bottom-left" />

// Top-right corner
<Agentation position="top-right" />

// Top-left corner
<Agentation position="top-left" />
```

## Changes

- Added `ToolbarPosition` type export
- Added `position` prop to `PageFeedbackToolbarCSSProps`
- Added CSS classes for position variants (`.bottomLeft`, `.topRight`, `.topLeft`)
- Updated toolbar container alignment for left-side positions
- Settings panel also adjusts position based on toolbar position

## Motivation

Some UIs have important elements in the bottom-right corner (e.g., chat widgets, floating action buttons). This prop allows users to position the Agentation toolbar elsewhere to avoid conflicts.

🤖 Generated with [Claude Code](https://claude.ai/code)