### PR TITLE
  feat: add source file detection for React components                                                                                                                                     

### DIFF
--- a/_package-export/CLAUDE.md
+++ b/_package-export/CLAUDE.md
@@ -40,6 +40,10 @@ The component exposes these callback props (added in 1.2.0):
 
 **API stability**: These are public contracts. Changing signatures or removing callbacks is a breaking change requiring a major version bump.
 
+**1.4.0 additions:**
+- `sourceAttribute` prop - configurable source detection attribute
+- `sourceFile`, `sourceComponent` on Annotation type
+
 **Expansion ideas** (for future consideration):
 - `onActivate` / `onDeactivate` - toolbar state changes
 - `getAnnotations()` ref method - programmatic access

--- a/_package-export/README.md
+++ b/_package-export/README.md
@@ -33,6 +33,7 @@ The toolbar appears in the bottom-right corner. Click to activate, then click an
 - **Area selection** – Drag to annotate any region, even empty space
 - **Animation pause** – Freeze CSS animations to capture specific states
 - **Structured output** – Copy markdown with selectors, positions, and context
+- **Source detection** – Shows file:line for React components (dev mode with TanStack Devtools)
 - **Programmatic access** – Callback prop for direct integration with tools
 - **Dark/light mode** – Matches your preference or set manually
 - **Zero dependencies** – Pure CSS animations, no runtime libraries
@@ -47,6 +48,7 @@ The toolbar appears in the bottom-right corner. Click to activate, then click an
 | `onAnnotationsClear` | `(annotations: Annotation[]) => void` | - | Called when all annotations are cleared |
 | `onCopy` | `(markdown: string) => void` | - | Callback with markdown output when copy is clicked |
 | `copyToClipboard` | `boolean` | `true` | Set to false to prevent writing to clipboard |
+| `sourceAttribute` | `string` | `"data-tsd-source"` | Data attribute to read source file path from |
 
 ### Programmatic Integration
 
@@ -102,6 +104,10 @@ type Annotation = {
   accessibility?: string;
   isMultiSelect?: boolean;
   isFixed?: boolean;
+
+  // Source location (dev mode only)
+  sourceFile?: string;           // e.g., "src/components/Button.tsx:42"
+  sourceComponent?: string;      // Component name if available
 };
 ```
 

--- a/_package-export/src/types.ts
+++ b/_package-export/src/types.ts
@@ -20,6 +20,10 @@ export type Annotation = {
   accessibility?: string;
   isMultiSelect?: boolean; // true if created via drag selection
   isFixed?: boolean; // true if element has fixed/sticky positioning (marker stays fixed)
+  /** Source file path with line number (dev mode only). e.g., "src/components/Button.tsx:42" */
+  sourceFile?: string;
+  /** React component name. e.g., "Button" */
+  sourceComponent?: string;
 };
 
 // TODO: Add configuration types when abstracting config


### PR DESCRIPTION
  ## Summary                                                                                                                                                                               
                                                                                                                                                                                           
  - Add `sourceAttribute` prop to configure which data attribute to read source location from                                                                                              
  - Add `sourceFile`, `sourceComponent`, `sourceUnavailableReason` fields to Annotation type                                                                                               
  - Detect source via `data-tsd-source` attribute (TanStack Devtools compatible)                                                                                                           
  - Fallback to React fiber `_debugSource` in dev mode                                                                                                                                     
                                                                                                                                                                                           
  ## Configurable source attribute                                                                                                                                                         
                                                                                                                                                                                           
  The `sourceAttribute` prop allows customizing which HTML data attribute is used to read source file paths:                                                                               
                                                                                                                                                                                           
  ```tsx                                                                                                                                                                                   
  // Default: reads from data-tsd-source (TanStack Devtools)                                                                                                                               
  <Agentation />                                                                                                                                                                           
                                                                                                                                                                                           
  // Custom: reads from your own data attribute                                                                                                                                            
  <Agentation sourceAttribute="data-my-source" />                                                                                                                                          
                                                                                                                                                                                           
  This makes the feature compatible with any tooling that injects source location as data attributes, not just TanStack Devtools.                                                          
                                                                                                                                                                                           
  Changes                                                                                                                                                                                  
                                                                                                                                                                                           
  - types.ts - New optional source fields on Annotation                                                                                                                                    
  - source-location.ts - Detection utilities with React 16-19 support                                                                                                                      
  - index.tsx - New sourceAttribute prop (default: "data-tsd-source")                                                                                                                      
  - README.md - Document new prop and fields                                                                                                                                               
  - CLAUDE.md - API changelog for 1.4.0                                                                                                                                                    
                                                                                                                                                                                           
  Use case                                                                                                                                                                                 
                                                                                                                                                                                           
  When annotating elements in dev mode, annotations now include the source file path (e.g., src/components/Button.tsx:42), helping AI agents locate the exact code being referenced.       