### PR TITLE
Fix unstyled MCP settings link

### DIFF
--- a/package/example/src/app/changelog/page.tsx
+++ b/package/example/src/app/changelog/page.tsx
@@ -30,6 +30,13 @@ function isMajorVersion(version: string): boolean {
 
 const releases: Release[] = [
   {
+    version: "2.1.1",
+    date: "February 5, 2026",
+    changes: [
+      { type: "fixed", text: "Unstyled \"Learn more\" link in MCP Connection settings when no endpoint is configured" },
+    ],
+  },
+  {
     version: "2.1.0",
     date: "February 5, 2026",
     changes: [

--- a/package/package.json
+++ b/package/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentation",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Visual feedback for AI coding agents",
   "license": "PolyForm-Shield-1.0.0",
   "main": "./dist/index.js",

--- a/package/src/components/page-toolbar-css/index.tsx
+++ b/package/src/components/page-toolbar-css/index.tsx
@@ -3500,7 +3500,7 @@ export function PageFeedbackToolbarCSS({
                         </span>
                       </Tooltip>
                     </span>
-                    {endpoint ? (
+                    {endpoint && (
                       <div
                         className={`${styles.mcpStatusDot} ${styles[connectionStatus]}`}
                         title={
@@ -3511,15 +3511,6 @@ export function PageFeedbackToolbarCSS({
                               : "Disconnected"
                         }
                       />
-                    ) : (
-                      <a
-                        href="https://agentation.dev/install#mcp-server"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className={styles.settingsLink}
-                      >
-                        Learn more →
-                      </a>
                     )}
                   </div>
                   <p


### PR DESCRIPTION
## Summary
- Remove broken "Learn more →" link in MCP Connection settings that used a nonexistent `.settingsLink` CSS class — the description paragraph below already has a properly styled "Learn more" link
- Bump to 2.1.1, add changelog entry

## Test plan
- [ ] Open toolbar settings with no MCP endpoint configured — "MCP Connection" heading should show cleanly without the unstyled link
- [ ] Open with MCP endpoint configured — status dot still appears as expected