### PR TITLE
Fix outdated MCP config path

### DIFF
--- a/package/example/src/app/install/page.tsx
+++ b/package/example/src/app/install/page.tsx
@@ -306,8 +306,21 @@ function App() {
             Add Agentation as an MCP server in your agent&apos;s config. Example for Claude Code:
           </p>
           <CodeBlock
-            code={`// Edit ~/.claude/claude_code_config.json
-{
+            code="claude mcp add agentation -- npx agentation-mcp server"
+            language="bash"
+            copyable
+          />
+          <p
+            style={{
+              fontSize: "0.875rem",
+              color: "rgba(0,0,0,0.5)",
+              marginTop: "0.5rem",
+            }}
+          >
+            Or add to your project&apos;s <code>.mcp.json</code> for team-wide config:
+          </p>
+          <CodeBlock
+            code={`{
   "mcpServers": {
     "agentation": {
       "command": "npx",

--- a/skills/agentation/SKILL.md
+++ b/skills/agentation/SKILL.md
@@ -43,25 +43,12 @@ Set up the Agentation annotation toolbar in this project.
    - Tell the user the Agentation toolbar component is configured
 
 6. **Check if MCP server already configured**
-   - Read `~/.claude/claude_code_config.json` if it exists
-   - Check if `mcpServers.agentation` entry exists
+   - Run `claude mcp list` to check if `agentation` MCP server is already registered
    - If yes, skip to final confirmation step
 
 7. **Configure Claude Code MCP server**
-   - Create `~/.claude/` directory if it doesn't exist
-   - Read existing `claude_code_config.json` if present (preserve other MCP servers)
-   - Add or merge the `mcpServers.agentation` entry:
-     ```json
-     {
-       "mcpServers": {
-         "agentation": {
-           "command": "npx",
-           "args": ["agentation-mcp", "server"]
-         }
-       }
-     }
-     ```
-   - Write updated config back to file
+   - Run: `claude mcp add agentation -- npx agentation-mcp server`
+   - This registers the MCP server with Claude Code automatically
 
 8. **Confirm full setup**
    - Tell the user both components are set up:


### PR DESCRIPTION
## Summary

Fixes #83 — the documented MCP config path `~/.claude/claude_code_config.json` is outdated and no longer used by Claude Code.

- **Install docs** (`package/example/`): Replace manual JSON edit with `claude mcp add` command, add `.mcp.json` as team-wide alternative
- **Skill** (`skills/agentation/SKILL.md`): Steps 6-7 now use `claude mcp add` / `claude mcp list` instead of reading/writing the old config file
- **CLI** (`mcp/src/cli.ts`): `init` command uses `claude mcp add`, `doctor` checks `~/.claude.json` (including per-project entries), help text updated

## Test plan

- [x] Verified `claude mcp add agentation -- npx agentation-mcp server` registers correctly to `~/.claude.json`
- [x] Verified `agentation-mcp doctor` detects the entry in `~/.claude.json` (all checks pass)
- [x] Verified `pnpm build` and `tsc --noEmit` pass with no errors
- [x] Confirmed zero remaining references to `claude_code_config.json`