### PR TITLE
Doctor warns about stale config, MCP page uses claude mcp add

### DIFF
--- a/mcp/src/cli.ts
+++ b/mcp/src/cli.ts
@@ -185,7 +185,13 @@ async function runDoctor() {
     results.push({ name: "Claude Code config", status: "warn", message: "No config found at ~/.claude.json. Run: claude mcp add agentation -- npx agentation-mcp server" });
   }
 
-  // Check 3: Server connectivity (try default port)
+  // Check 3: Stale config at old (wrong) path
+  const oldConfigPath = path.join(homeDir, ".claude", "claude_code_config.json");
+  if (fs.existsSync(oldConfigPath)) {
+    results.push({ name: "Stale config", status: "warn", message: `${oldConfigPath} exists but Claude Code doesn't read this file. Safe to delete.` });
+  }
+
+  // Check 4: Server connectivity (try default port)
   try {
     const response = await fetch("http://localhost:4747/health", { signal: AbortSignal.timeout(2000) });
     if (response.ok) {

--- a/package/example/src/app/mcp/page.tsx
+++ b/package/example/src/app/mcp/page.tsx
@@ -103,10 +103,9 @@ npx agentation-mcp help      # Show help`}
           <CodeBlock language="bash" copyable code={`npx agentation-mcp server`} />
 
           <h3>2. Add the MCP server to Claude Code</h3>
-          <CodeBlock language="bash" copyable code={`npx agentation-mcp init`} />
+          <CodeBlock language="bash" copyable code={`claude mcp add agentation -- npx agentation-mcp server`} />
           <p style={{ fontSize: "0.8125rem", color: "rgba(0,0,0,0.55)", marginTop: "0.5rem" }}>
-            This runs the interactive setup wizard to configure Claude Code. Once connected, Claude can
-            use all the Agentation tools to read and respond to your annotations.
+            Or use the interactive setup wizard: <code>npx agentation-mcp init</code>
           </p>
 
           <h3>3. Verify the connection</h3>


### PR DESCRIPTION
Follow-up to #85. Two small additions:
- doctor command warns if old claude_code_config.json exists
- MCP docs page shows claude mcp add as primary method