### PR TITLE
Codex support to Agentation MCP setup and diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Agentation
+
+Monorepo containing:
+
+1. **npm package** (`package/`) - See `package/AGENTS.md`
+2. **Website/docs** (`package/example/`) - See `package/example/AGENTS.md`
+
+## What is Agentation?
+
+A floating toolbar for annotating web pages and collecting structured feedback for AI coding agents.
+
+## Development
+
+```bash
+pnpm install    # Install all workspace dependencies
+pnpm dev        # Run both package watch + website dev server
+pnpm build      # Build package only
+```
+
+## Important
+
+The npm package is public. Changes to `package/src/` affect all users.
+Website changes (`package/example/`) only affect agentation.dev.
+
+## PR/Issue Approach
+
+- Package size is critical - avoid bloat
+- UI changes need extra scrutiny
+- Plugins/extensions -> encourage separate repos
+- External binary files -> never accept
+
+## Annotations (Codex)
+
+Whenever the user brings up annotations, fetch all pending annotations before doing anything else.
+
+Use this flow:
+1. Call `agentation_get_all_pending`.
+2. For each actionable annotation, call `agentation_acknowledge` before edits.
+3. After implementing, call `agentation_resolve` with a concise summary.
+4. If feedback is invalid/outdated, call `agentation_dismiss` with a reason.
+5. If user asks for watch mode, loop on `agentation_watch_annotations` until stopped.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,10 @@ Website changes (`package/example/`) only affect agentation.dev.
 - Plugins/extensions → encourage separate repos
 - External binary files → never accept
 
-## Annotations
+## Annotations (Claude Code)
 
 Whenever the user brings up annotations, fetch all the pending annotations before doing anything else. And infer whether I am referencing any annotations.
+
+## Codex
+
+Use the equivalent Codex instructions in `AGENTS.md` (same annotation-first workflow, codex-specific wording).

--- a/mcp/AGENTS.md
+++ b/mcp/AGENTS.md
@@ -1,0 +1,18 @@
+# Agentation MCP (Codex)
+
+MCP server package for Agentation.
+
+## Scope
+
+- `src/cli.ts` handles setup (`init`), diagnostics (`doctor`), and server startup.
+- `src/server/` contains HTTP + MCP transport and tool implementations.
+
+## Integration Rules
+
+- Keep `Claude Code (Claude)` instructions intact and clearly labeled.
+- Add `Codex` instructions immediately after the Claude section.
+- Keep Claude as the default selection in setup flows.
+
+## Validation
+
+After CLI changes, run `pnpm --filter agentation-mcp build`.

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -19,34 +19,34 @@ pnpm add agentation-mcp
 Run the interactive setup wizard:
 
 ```bash
-agentation-mcp init
+npx agentation-mcp init
 ```
 
-This will configure Claude Code to use the Agentation MCP server.
+This asks which coding agent you want to configure (`Claude Code` by default, or `Codex`) and then updates the right config file.
 
 ### 2. Start the server
 
 ```bash
-agentation-mcp server
+npx agentation-mcp server
 ```
 
 This starts both:
 - **HTTP server** (port 4747) - receives annotations from the browser toolbar
-- **MCP server** (stdio) - exposes tools for Claude Code
+- **MCP server** (stdio) - exposes tools for Claude Code or Codex
 
 ### 3. Verify your setup
 
 ```bash
-agentation-mcp doctor
+npx agentation-mcp doctor
 ```
 
 ## CLI Commands
 
 ```bash
-agentation-mcp init                    # Interactive setup wizard
-agentation-mcp server [options]        # Start the annotation server
-agentation-mcp doctor                  # Check your setup
-agentation-mcp help                    # Show help
+npx agentation-mcp init                    # Interactive setup wizard
+npx agentation-mcp server [options]        # Start the annotation server
+npx agentation-mcp doctor                  # Check your setup
+npx agentation-mcp help                    # Show help
 ```
 
 ### Server Options
@@ -72,6 +72,45 @@ The MCP server exposes these tools to AI agents:
 | `agentation_dismiss` | Dismiss an annotation with a reason |
 | `agentation_reply` | Add a reply to an annotation thread |
 | `agentation_watch_annotations` | Block until new annotations appear, then return batch |
+
+## Agent Config Directions
+
+### Claude Code (Claude)
+
+Use the setup wizard and choose `Claude Code` (or press Enter for default):
+
+```bash
+npx agentation-mcp init
+```
+
+This updates `~/.claude/claude_code_config.json` with:
+
+```json
+{
+  "mcpServers": {
+    "agentation": {
+      "command": "npx",
+      "args": ["agentation-mcp", "server"]
+    }
+  }
+}
+```
+
+### Codex
+
+Use the setup wizard and choose `Codex`:
+
+```bash
+npx agentation-mcp init
+```
+
+This updates `~/.codex/config.toml` with:
+
+```toml
+[mcp_servers.agentation]
+command = "npx"
+args = ["-y", "agentation-mcp", "server"]
+```
 
 ## HTTP API
 
@@ -156,7 +195,7 @@ await startMcpServer('http://localhost:4747');
 By default, data is persisted to SQLite at `~/.agentation/store.db`. To use in-memory storage:
 
 ```bash
-AGENTATION_STORE=memory agentation-mcp server
+AGENTATION_STORE=memory npx agentation-mcp server
 ```
 
 ## License

--- a/package/AGENTS.md
+++ b/package/AGENTS.md
@@ -1,0 +1,51 @@
+# Agentation Package (Codex)
+
+This is the publishable npm package. Changes here affect everyone who installs `agentation`.
+
+## Critical Rules
+
+1. **NEVER run `npm publish`** - Only publish when explicitly instructed.
+2. **NEVER bump version** in `package.json` without explicit instruction.
+3. **NEVER modify exports** in `src/index.ts` without discussing breaking changes.
+
+## What Gets Published
+
+- `dist/` folder (compiled from `src/`)
+- `package.json`, `README.md`, `LICENSE`
+
+## Before Modifying `src/`
+
+- Consider: Is this a breaking change?
+- Consider: Does this affect the API surface?
+- Consider: Will existing users' code still work?
+
+## Main Export
+
+```tsx
+import { Agentation } from 'agentation';
+```
+
+No external runtime dependencies beyond React.
+
+## Programmatic API
+
+Public callback props include:
+
+- `onAnnotationAdd(annotation)`
+- `onAnnotationDelete(annotation)`
+- `onAnnotationUpdate(annotation)`
+- `onAnnotationsClear(annotations[])`
+- `onCopy(markdown)`
+- `copyToClipboard` (boolean, default: true)
+
+These are public contracts. Signature/removal changes are breaking changes.
+
+## Testing Changes
+
+1. Run `pnpm build` to ensure it compiles.
+2. Check the example app still works with `pnpm dev`.
+3. Verify no TypeScript errors in consumers.
+
+## Annotation Workflow (Codex)
+
+When user feedback references annotations, fetch pending annotations first and resolve them via MCP tools.

--- a/package/CLAUDE.md
+++ b/package/CLAUDE.md
@@ -1,4 +1,4 @@
-# Agentation Package
+# Agentation Package (Claude Code)
 
 This is the publishable npm package. Changes here affect everyone who installs `agentation`.
 
@@ -64,3 +64,7 @@ When instructed to publish a new npm version:
 7. Commit and push the changelog update
 
 Always analyze what changed since the last version to write accurate changelog entries.
+
+## Codex
+
+Use the Codex counterpart instructions in `package/AGENTS.md`.

--- a/package/example/AGENTS.md
+++ b/package/example/AGENTS.md
@@ -1,0 +1,26 @@
+# Agentation Website (Codex)
+
+Demo site and documentation at agentation.dev.
+
+## Safe but Important
+
+- Changes here do not affect npm package consumers.
+- This is the public face of the project; keep it accurate and polished.
+- Content should be clear and helpful for potential users.
+- If demos break, investigate whether the package has a bug.
+
+## Structure
+
+- `src/app/` - Next.js app router pages.
+- Pages include features, FAQ, install, MCP, and API docs.
+
+## Development
+
+```bash
+pnpm dev                                    # From root (starts both)
+pnpm --filter feedback-tool-example dev     # Website only
+```
+
+## Agentation Docs Rule
+
+When documenting integrations, keep `Claude Code (Claude)` directions explicit and place the `Codex` directions immediately after.

--- a/package/example/CLAUDE.md
+++ b/package/example/CLAUDE.md
@@ -1,4 +1,4 @@
-# Agentation Website
+# Agentation Website (Claude Code)
 
 Demo site and documentation at agentation.dev.
 
@@ -26,3 +26,7 @@ Deployed automatically via Vercel on push to main.
 ## Note
 
 If something breaks in the demos, it might indicate a bug in the package itself. Use this as a testing ground for the library.
+
+## Codex
+
+Use the Codex counterpart instructions in `package/example/AGENTS.md`.

--- a/package/example/src/app/install/page.tsx
+++ b/package/example/src/app/install/page.tsx
@@ -256,7 +256,7 @@ function App() {
         </section>
 
         <section>
-          <h2>Claude Code</h2>
+          <h2>Claude Code (Claude)</h2>
           <p>
             If you use Claude Code, you can set up Agentation automatically with the <code>/agentation</code> skill. Install it:
           </p>
@@ -273,6 +273,21 @@ function App() {
             }}
           >
             Detects your framework, installs the package, wires it into your layout, and configures the MCP server for auto-start.
+          </p>
+
+          <h2 style={{ marginTop: "2rem" }}>Codex</h2>
+          <p>
+            For Codex, add Agentation MCP directly:
+          </p>
+          <CodeBlock code="codex mcp add npx -y agentation-mcp server agentation" language="bash" copyable />
+          <p
+            style={{
+              fontSize: "0.8125rem",
+              color: "rgba(0,0,0,0.45)",
+              marginTop: "0.375rem",
+            }}
+          >
+            Or run <code>npx agentation-mcp init</code>, select <code>Codex</code>, and it will update <code>~/.codex/config.toml</code>.
           </p>
         </section>
 
@@ -303,7 +318,10 @@ function App() {
 
           <h3>2. Configure your agent</h3>
           <p>
-            Add Agentation as an MCP server in your agent&apos;s config. Example for Claude Code:
+            Add Agentation as an MCP server in your agent&apos;s config.
+          </p>
+          <p style={{ marginBottom: "0.5rem" }}>
+            <strong>Claude Code (Claude):</strong>
           </p>
           <CodeBlock
             code="claude mcp add agentation -- npx agentation-mcp server"
@@ -329,6 +347,17 @@ function App() {
   }
 }`}
             language="json"
+          />
+
+          <p style={{ marginTop: "1rem", marginBottom: "0.5rem" }}>
+            <strong>Codex:</strong>
+          </p>
+          <CodeBlock
+            code={`# Edit ~/.codex/config.toml
+[mcp_servers.agentation]
+command = "npx"
+args = ["-y", "agentation-mcp", "server"]`}
+            language="toml"
           />
 
           <h3>3. Connect the component</h3>

--- a/package/example/src/app/mcp/page.tsx
+++ b/package/example/src/app/mcp/page.tsx
@@ -59,7 +59,7 @@ pnpm add agentation-mcp`}
           <p>Run the interactive setup wizard:</p>
           <CodeBlock language="bash" copyable code={`npx agentation-mcp init`} />
           <p style={{ fontSize: "0.8125rem", color: "rgba(0,0,0,0.55)", marginTop: "0.5rem" }}>
-            This configures Claude Code to use the Agentation MCP server.
+            This asks which coding agent to configure. Default is <code>Claude Code</code>, with <code>Codex</code> also supported.
           </p>
 
           <h3>2. Start the server</h3>
@@ -94,7 +94,7 @@ npx agentation-mcp help      # Show help`}
         </section>
 
         <section>
-          <h2 id="claude-code">Claude Code</h2>
+          <h2 id="claude-code">Claude Code (Claude)</h2>
           <p>
             To connect Claude Code to the Agentation MCP server:
           </p>
@@ -113,6 +113,27 @@ npx agentation-mcp help      # Show help`}
             In Claude Code, you can verify the server is connected by asking Claude to list your
             annotation sessions. If the server is running, Claude will be able to use the{" "}
             <code>agentation_list_sessions</code> tool.
+          </p>
+
+          <h2 id="codex" style={{ marginTop: "2rem" }}>Codex</h2>
+          <p>
+            To connect Codex to the Agentation MCP server:
+          </p>
+
+          <h3>1. Start the server</h3>
+          <CodeBlock language="bash" copyable code={`npx agentation-mcp server`} />
+
+          <h3>2. Add MCP server to Codex</h3>
+          <CodeBlock language="bash" copyable code={`codex mcp add npx -y agentation-mcp server agentation`} />
+          <p style={{ fontSize: "0.8125rem", color: "rgba(0,0,0,0.55)", marginTop: "0.5rem" }}>
+            Or run <code>npx agentation-mcp init</code> and select <code>Codex</code>. This updates{" "}
+            <code>~/.codex/config.toml</code>.
+          </p>
+
+          <h3>3. Verify the connection</h3>
+          <p style={{ fontSize: "0.8125rem", color: "rgba(0,0,0,0.55)" }}>
+            Run <code>npx agentation-mcp doctor</code>, choose <code>Codex</code>, then ask the agent to call{" "}
+            <code>agentation_list_sessions</code>.
           </p>
         </section>
 

--- a/package/hooks/README.md
+++ b/package/hooks/README.md
@@ -2,6 +2,9 @@
 
 This hook automatically injects pending UI annotations into Claude's context on every user message.
 
+> Claude-specific: these hook instructions are for Claude Code.  
+> Codex: use MCP setup (`codex mcp add npx -y agentation-mcp server agentation`) and add workflow instructions in `AGENTS.md`.
+
 ## Quick Setup
 
 ### Option 1: One-liner (recommended)


### PR DESCRIPTION
## Summary

This PR adds first-class Codex support to Agentation MCP setup and diagnostics, while keeping Claude Code as the default path. It also updates docs and repo guidance so both agents are documented consistently.

## What changed

- CLI (`mcp/src/cli.ts`)
  - `init` now prompts for coding agent (`Claude Code` default, `Codex` optional).
  - Writes config to the correct target:
    - Claude: `~/.claude/claude_code_config.json`
    - Codex: `~/.codex/config.toml`
  - Keeps automatic `claude mcp add ...` registration for Claude path.
  - Uses `npx -y agentation-mcp server` for test-start flow.
  - `doctor` now checks the selected agent config and probes server health on the configured port.

- MCP/docs/site updates
  - Updated `mcp/README.md` to document both Claude and Codex setup flows.
  - Updated install/MCP website pages with explicit Codex instructions.
  - Clarified Claude-vs-Codex wording in `CLAUDE.md` and related docs.

- Agent guidance
  - Added Codex-focused `AGENTS.md` files at root/package/example/mcp.
  - Included annotation-first workflow and doc placement rules for Claude/Codex sections.

## Why

Users were getting agent-specific setup confusion. This makes setup explicit per agent, reduces config-path mistakes, and keeps onboarding docs aligned with actual CLI behavior.

## Validation

- `pnpm --filter agentation-mcp build` ✅
