### PR TITLE
Fix resolved annotations reappearing in the browser

### DIFF
--- a/package/src/components/page-toolbar-css/index.test.tsx
+++ b/package/src/components/page-toolbar-css/index.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, fireEvent, waitFor } from "@testing-library/react";
 import { PageFeedbackToolbarCSS } from "./index";
 import type { Annotation } from "../../types";
+import { getStorageKey } from "../../utils/storage";
 
 // Mock clipboard API
 const mockClipboard = {
@@ -9,6 +10,24 @@ const mockClipboard = {
 };
 
 beforeEach(() => {
+  const storage = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => storage.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      storage.set(key, String(value));
+    },
+    removeItem: (key: string) => {
+      storage.delete(key);
+    },
+    clear: () => {
+      storage.clear();
+    },
+    key: (index: number) => Array.from(storage.keys())[index] ?? null,
+    get length() {
+      return storage.size;
+    },
+  });
+
   vi.stubGlobal("navigator", {
     clipboard: mockClipboard,
     userAgent: "test-agent",
@@ -76,6 +95,282 @@ describe("PageFeedbackToolbarCSS", () => {
           />
         )
       ).not.toThrow();
+    });
+  });
+
+  describe("reconnect sync filtering", () => {
+    it("should exclude resolved and dismissed annotations from copy output after reconnect sync", async () => {
+      const onCopy = vi.fn();
+      const now = Date.now();
+      const pathname = window.location.pathname;
+      const storageKey = getStorageKey(pathname);
+      const expectedInitWarn =
+        "[Agentation] Failed to initialize session, using local storage:";
+      const originalWarn = console.warn;
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation((...args) => {
+        if (args[0] === expectedInitWarn) {
+          return;
+        }
+        originalWarn(...args);
+      });
+
+      try {
+        const localAnnotations: Annotation[] = [
+          {
+            id: "pending-1",
+            x: 10,
+            y: 20,
+            comment: "Pending feedback",
+            element: "Button",
+            elementPath: "body > button",
+            timestamp: now,
+            status: "pending",
+          },
+          {
+            id: "resolved-1",
+            x: 20,
+            y: 30,
+            comment: "Resolved feedback",
+            element: "Card",
+            elementPath: "body > div.card",
+            timestamp: now,
+            status: "resolved",
+          },
+          {
+            id: "dismissed-1",
+            x: 30,
+            y: 40,
+            comment: "Dismissed feedback",
+            element: "Nav",
+            elementPath: "body > nav",
+            timestamp: now,
+            status: "dismissed",
+          },
+        ];
+
+        const jsonResponse = (data: unknown, ok = true) =>
+          ({
+            ok,
+            status: ok ? 200 : 500,
+            json: async () => data,
+          }) as Response;
+
+        class MockEventSource {
+          constructor(_url: string) {}
+          addEventListener(_type: string, _listener: EventListener) {}
+          removeEventListener(_type: string, _listener: EventListener) {}
+          close() {}
+        }
+
+        let createSessionCalls = 0;
+        let resolveHealth: ((value: Response) => void) | null = null;
+        const healthPromise = new Promise<Response>((resolve) => {
+          resolveHealth = resolve;
+        });
+
+        const fetchMock = vi.fn(
+          async (input: RequestInfo | URL, init?: RequestInit) => {
+            const url = String(input);
+            const method = init?.method ?? "GET";
+
+            if (url === "http://api/health" && method === "GET") {
+              return healthPromise;
+            }
+
+            if (url === "http://api/sessions" && method === "POST") {
+              createSessionCalls += 1;
+              // First create attempt is during initSession; fail it to force
+              // disconnected -> connected transition via health check.
+              if (createSessionCalls === 1) {
+                throw new Error("init createSession failed");
+              }
+              return jsonResponse({
+                id: "reconnect-session",
+                url: "http://example.com",
+                status: "active",
+                createdAt: new Date(now).toISOString(),
+              });
+            }
+
+            if (
+              url === "http://api/sessions/reconnect-session/annotations" &&
+              method === "POST"
+            ) {
+              const payload = JSON.parse(String(init?.body ?? "{}")) as Annotation;
+              return jsonResponse(payload);
+            }
+
+            throw new Error(`Unexpected fetch call: ${method} ${url}`);
+          },
+        );
+
+        vi.stubGlobal("fetch", fetchMock);
+        vi.stubGlobal("EventSource", MockEventSource);
+
+        localStorage.removeItem(storageKey);
+
+        render(
+          <PageFeedbackToolbarCSS
+            endpoint="http://api"
+            copyToClipboard={false}
+            onCopy={onCopy}
+          />,
+        );
+
+        await waitFor(() => {
+          const createCalls = fetchMock.mock.calls.filter(
+            ([url, init]) =>
+              String(url) === "http://api/sessions" &&
+              (init?.method ?? "GET") === "POST",
+          );
+          expect(createCalls.length).toBeGreaterThanOrEqual(1);
+        });
+
+        await waitFor(() => {
+          expect(warnSpy).toHaveBeenCalledWith(expectedInitWarn, expect.any(Error));
+        });
+
+        // Seed mixed-status local annotations while disconnected.
+        localStorage.setItem(storageKey, JSON.stringify(localAnnotations));
+
+        // Resolve health check as connected so reconnect sync effect runs.
+        resolveHealth?.(jsonResponse({}, true));
+
+        await waitFor(() => {
+          const syncCalls = fetchMock.mock.calls.filter(
+            ([url, init]) =>
+              String(url) === "http://api/sessions/reconnect-session/annotations" &&
+              (init?.method ?? "GET") === "POST",
+          );
+          expect(syncCalls).toHaveLength(3);
+        });
+
+        fireEvent.keyDown(document, { key: "c" });
+
+        await waitFor(() => {
+          expect(onCopy).toHaveBeenCalled();
+        });
+
+        const output = String(onCopy.mock.calls.at(-1)?.[0] ?? "");
+        expect(output).toContain("Pending feedback");
+        expect(output).not.toContain("Resolved feedback");
+        expect(output).not.toContain("Dismissed feedback");
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("should exclude resolved annotations returned by init session sync from copy output", async () => {
+      const onCopy = vi.fn();
+      const now = Date.now();
+      const pathname = window.location.pathname;
+      const storageKey = getStorageKey(pathname);
+
+      const localAnnotations: Annotation[] = [
+        {
+          id: "pending-init-keep",
+          x: 10,
+          y: 20,
+          comment: "Pending init feedback keep",
+          element: "Button",
+          elementPath: "body > button",
+          timestamp: now,
+          status: "pending",
+        },
+        {
+          id: "pending-init-to-resolve",
+          x: 20,
+          y: 30,
+          comment: "Pending init feedback to resolve",
+          element: "Card",
+          elementPath: "body > div.card",
+          timestamp: now,
+          status: "pending",
+        },
+      ];
+
+      const jsonResponse = (data: unknown, ok = true) =>
+        ({
+          ok,
+          status: ok ? 200 : 500,
+          json: async () => data,
+        }) as Response;
+
+      class MockEventSource {
+        constructor(_url: string) {}
+        addEventListener(_type: string, _listener: EventListener) {}
+        removeEventListener(_type: string, _listener: EventListener) {}
+        close() {}
+      }
+
+      const fetchMock = vi.fn(
+        async (input: RequestInfo | URL, init?: RequestInit) => {
+          const url = String(input);
+          const method = init?.method ?? "GET";
+
+          if (url === "http://api/health" && method === "GET") {
+            return jsonResponse({}, true);
+          }
+
+          if (url === "http://api/sessions" && method === "POST") {
+            return jsonResponse({
+              id: "init-session",
+              url: "http://example.com",
+              status: "active",
+              createdAt: new Date(now).toISOString(),
+            });
+          }
+
+          if (
+            url === "http://api/sessions/init-session/annotations" &&
+            method === "POST"
+          ) {
+            const payload = JSON.parse(String(init?.body ?? "{}")) as Annotation;
+            if (payload.id === "pending-init-to-resolve") {
+              return jsonResponse({
+                ...payload,
+                status: "resolved",
+                comment: "Resolved by server during init sync",
+              });
+            }
+            return jsonResponse(payload);
+          }
+
+          throw new Error(`Unexpected fetch call: ${method} ${url}`);
+        },
+      );
+
+      vi.stubGlobal("fetch", fetchMock);
+      vi.stubGlobal("EventSource", MockEventSource);
+
+      localStorage.setItem(storageKey, JSON.stringify(localAnnotations));
+
+      render(
+        <PageFeedbackToolbarCSS
+          endpoint="http://api"
+          copyToClipboard={false}
+          onCopy={onCopy}
+        />,
+      );
+
+      await waitFor(() => {
+        const syncCalls = fetchMock.mock.calls.filter(
+          ([url, init]) =>
+            String(url) === "http://api/sessions/init-session/annotations" &&
+            (init?.method ?? "GET") === "POST",
+        );
+        expect(syncCalls).toHaveLength(2);
+      });
+
+      fireEvent.keyDown(document, { key: "c" });
+
+      await waitFor(() => {
+        expect(onCopy).toHaveBeenCalled();
+      });
+
+      const output = String(onCopy.mock.calls.at(-1)?.[0] ?? "");
+      expect(output).toContain("Pending init feedback keep");
+      expect(output).not.toContain("Resolved by server during init sync");
     });
   });
 });

--- a/package/src/components/page-toolbar-css/index.tsx
+++ b/package/src/components/page-toolbar-css/index.tsx
@@ -260,6 +260,10 @@ function formatRelativeTime(dateString: string): string {
   return date.toLocaleDateString();
 }
 
+function isRenderableAnnotation(annotation: Annotation): boolean {
+  return annotation.status !== "resolved" && annotation.status !== "dismissed";
+}
+
 function truncateUrl(url: string): string {
   try {
     const parsed = new URL(url);
@@ -777,7 +781,7 @@ export function PageFeedbackToolbarCSS({
     setMounted(true);
     setScrollY(window.scrollY);
     const stored = loadAnnotations<Annotation>(pathname);
-    setAnnotations(stored);
+    setAnnotations(stored.filter(isRenderableAnnotation));
 
     // Trigger entrance animation only on first load (not on SPA navigation)
     if (!hasPlayedEntranceAnimation) {
@@ -924,17 +928,19 @@ export function PageFeedbackToolbarCSS({
                 ...session.annotations,
                 ...syncedAnnotations,
               ];
-              setAnnotations(allAnnotations);
+              setAnnotations(allAnnotations.filter(isRenderableAnnotation));
               saveAnnotationsWithSyncMarker(
                 pathname,
-                allAnnotations,
+                allAnnotations.filter(isRenderableAnnotation),
                 session.id,
               );
             } else {
-              setAnnotations(session.annotations);
+              setAnnotations(
+                session.annotations.filter(isRenderableAnnotation),
+              );
               saveAnnotationsWithSyncMarker(
                 pathname,
-                session.annotations,
+                session.annotations.filter(isRenderableAnnotation),
                 session.id,
               );
             }
@@ -1007,11 +1013,14 @@ export function PageFeedbackToolbarCSS({
                     );
                     return unsyncedAnnotations[i];
                   });
+                  const renderableSyncedAnnotations = syncedAnnotations.filter(
+                    isRenderableAnnotation,
+                  );
 
                   // Save with sync marker
                   saveAnnotationsWithSyncMarker(
                     pagePath,
-                    syncedAnnotations,
+                    renderableSyncedAnnotations,
                     targetSession.id,
                   );
 
@@ -1023,7 +1032,7 @@ export function PageFeedbackToolbarCSS({
                       const newDuringSync = prev.filter(
                         (a) => !originalIds.has(a.id),
                       );
-                      return [...syncedAnnotations, ...newDuringSync];
+                      return [...renderableSyncedAnnotations, ...newDuringSync];
                     });
                   }
                 } catch (err) {
@@ -1180,8 +1189,15 @@ export function PageFeedbackToolbarCSS({
 
             // Update local state with server + synced annotations
             const allAnnotations = [...serverAnnotations, ...syncedAnnotations];
-            setAnnotations(allAnnotations);
-            saveAnnotationsWithSyncMarker(pathname, allAnnotations, sessionId!);
+            const renderableAnnotations = allAnnotations.filter(
+              isRenderableAnnotation,
+            );
+            setAnnotations(renderableAnnotations);
+            saveAnnotationsWithSyncMarker(
+              pathname,
+              renderableAnnotations,
+              sessionId!,
+            );
           }
         } catch (err) {
           console.warn("[Agentation] Failed to sync on reconnect:", err);
@@ -2899,7 +2915,7 @@ export function PageFeedbackToolbarCSS({
 
   // Filter annotations for rendering (exclude exiting ones from normal flow)
   const visibleAnnotations = annotations.filter(
-    (a) => !exitingMarkers.has(a.id),
+    (a) => !exitingMarkers.has(a.id) && isRenderableAnnotation(a),
   );
   const exitingAnnotationsList = annotations.filter((a) =>
     exitingMarkers.has(a.id),


### PR DESCRIPTION
This fixes annotation filtering so resolved/dismissed items are not shown. (Fixes #94.) It also adds tests for the new filtering.