### PR TITLE
fix: redirect server logs to stderr to avoid corrupting MCP stdio

### DIFF
--- a/mcp/src/server/store.ts
+++ b/mcp/src/server/store.ts
@@ -43,7 +43,7 @@ export function getStore(): AFSStore {
 function initializeStore(): AFSStore {
   // Check if we should use in-memory only
   if (process.env.AGENTATION_STORE === "memory") {
-    console.log("[Store] Using in-memory store (AGENTATION_STORE=memory)");
+    process.stderr.write("[Store] Using in-memory store (AGENTATION_STORE=memory)\n");
     return createMemoryStore();
   }
 
@@ -52,7 +52,7 @@ function initializeStore(): AFSStore {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { createSQLiteStore } = require("./sqlite.js");
     const store = createSQLiteStore();
-    console.log("[Store] Using SQLite store (~/.agentation/store.db)");
+    process.stderr.write("[Store] Using SQLite store (~/.agentation/store.db)\n");
     return store;
   } catch (err) {
     console.warn("[Store] SQLite unavailable, falling back to in-memory:", (err as Error).message);

--- a/mcp/src/server/tenant-store.ts
+++ b/mcp/src/server/tenant-store.ts
@@ -50,7 +50,7 @@ function initializeTenantStore(): import("./sqlite.js").TenantStore {
     // eslint-disable-next-line @typescript-eslint/no-require-imports
     const { createTenantStore } = require("./sqlite.js");
     const store = createTenantStore();
-    console.log("[TenantStore] Initialized tenant store");
+    process.stderr.write("[TenantStore] Initialized tenant store\n");
     return store;
   } catch (err) {
     console.error("[TenantStore] Failed to initialize:", (err as Error).message);


### PR DESCRIPTION
## Summary

When running `agentation-mcp server` (without `--mcp-only`), both the HTTP server and MCP stdio server share the same process. stdout is reserved for JSON-RPC messages per the MCP spec, but several `console.log()` calls were writing diagnostic output to stdout, corrupting the protocol stream and causing MCP clients to fail the stdio handshake.

The MCP server code in `mcp.ts` already correctly uses `console.error` for its startup messages, but the HTTP server, store, and tenant-store modules were using `console.log`.

### What this fixes

- MCP clients can now connect using `agentation-mcp server` (not just `server --mcp-only`)
- The `--mcp-only` flag is no longer required for clean stdio operation

### Changes

- **`http.ts`**: Add a `log()` helper that writes to stderr, replace all `console.log` calls with it
- **`store.ts`**: Replace `console.log` with `process.stderr.write`
- **`tenant-store.ts`**: Replace `console.log` with `process.stderr.write`
- **`http.ts`**: Handle `EADDRINUSE` gracefully so if the port is taken, a message is logged to stderr and the MCP stdio server continues running

### How to reproduce

```bash
# This hangs / fails MCP handshake (stdout gets "[HTTP] Agentation server listening..." before JSON-RPC)
echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | npx agentation-mcp server 2>/dev/null

# This works (pure stdio, no HTTP server logs on stdout)
echo '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}' | npx agentation-mcp server --mcp-only 2>/dev/null
```

After this fix, both commands work correctly.

## Test plan

- [ ] Run `agentation-mcp server` and verify HTTP startup message appears on stderr, not stdout
- [ ] Verify MCP stdio handshake succeeds with `agentation-mcp server` (without `--mcp-only`)
- [ ] Verify `agentation-mcp server --mcp-only` still works as before
- [ ] Verify HTTP request logging still appears on stderr during normal operation
- [ ] Start two instances on the same port and verify the second logs EADDRINUSE to stderr and continues MCP stdio