### PR TITLE
feat: instant tooltips when moving between buttons in toolbar

### DIFF
--- a/package/src/components/page-toolbar-css/index.tsx
+++ b/package/src/components/page-toolbar-css/index.tsx
@@ -529,6 +529,10 @@ export function PageFeedbackToolbarCSS({
   );
   const [isTransitioning, setIsTransitioning] = useState(false);
   const [tooltipsHidden, setTooltipsHidden] = useState(false);
+  const [tooltipSessionActive, setTooltipSessionActive] = useState(false);
+  const tooltipSessionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
   // Cmd+shift+click multi-select state
   const [pendingMultiSelectElements, setPendingMultiSelectElements] = useState<
@@ -550,6 +554,31 @@ export function PageFeedbackToolbarCSS({
   const showTooltipsAgain = () => {
     setTooltipsHidden(false);
   };
+
+  const handleControlsMouseEnter = () => {
+    if (!tooltipSessionActive) {
+      tooltipSessionTimerRef.current = setTimeout(
+        () => setTooltipSessionActive(true),
+        850,
+      );
+    }
+  };
+
+  const handleControlsMouseLeave = () => {
+    if (tooltipSessionTimerRef.current) {
+      clearTimeout(tooltipSessionTimerRef.current);
+      tooltipSessionTimerRef.current = null;
+    }
+    setTooltipSessionActive(false);
+    showTooltipsAgain();
+  };
+
+  useEffect(() => {
+    return () => {
+      if (tooltipSessionTimerRef.current)
+        clearTimeout(tooltipSessionTimerRef.current);
+    };
+  }, []);
 
   // Tooltip component that renders via portal to escape overflow clipping
   const Tooltip = ({
@@ -3016,8 +3045,9 @@ export function PageFeedbackToolbarCSS({
               toolbarPosition && toolbarPosition.y < 100
                 ? styles.tooltipBelow
                 : ""
-            } ${tooltipsHidden || showSettings ? styles.tooltipsHidden : ""}`}
-            onMouseLeave={showTooltipsAgain}
+            } ${tooltipsHidden || showSettings ? styles.tooltipsHidden : ""} ${tooltipSessionActive ? styles.tooltipsInSession : ""}`}
+            onMouseEnter={handleControlsMouseEnter}
+            onMouseLeave={handleControlsMouseLeave}
           >
             <div
               className={`${styles.buttonWrapper} ${

--- a/package/src/components/page-toolbar-css/styles.module.scss
+++ b/package/src/components/page-toolbar-css/styles.module.scss
@@ -575,6 +575,10 @@ $green: #34c759;
   }
 }
 
+.tooltipsInSession .buttonWrapper:hover .buttonTooltip {
+  transition-delay: 0s;
+}
+
 // Send button wrapper - animates width when MCP connects/disconnects
 .sendButtonWrapper {
   width: 0;


### PR DESCRIPTION
The first hover keeps 0.85s delay; subsequent hovers within the bar show tooltips with no delay. Resets when the pointer leaves the toolbar.

My reasoning behind this is that from a UX perspective it's generally best to have an initial delay to make sure a user really wants to see the tooltip but then display other tooltips in the same group instantly to make it feel more snappy and sleek. I personally stumbled over this and think that it would make a nice quality of life improvement.