### PR TITLE
fix: Keyboard activation & inert when collapsed

### DIFF
--- a/package/src/components/page-toolbar-css/index.test.tsx
+++ b/package/src/components/page-toolbar-css/index.test.tsx
@@ -78,6 +78,84 @@ describe("PageFeedbackToolbarCSS", () => {
       ).not.toThrow();
     });
   });
+
+  describe("inert when collapsed", () => {
+    it("should set inert on controls and settings when toolbar is collapsed", () => {
+      render(<PageFeedbackToolbarCSS />);
+      const toolbar = document.querySelector("[data-feedback-toolbar]");
+      expect(toolbar).toBeTruthy();
+      const inertElements = toolbar?.querySelectorAll("[inert]") ?? [];
+      expect(inertElements.length).toBeGreaterThanOrEqual(2); // controls content + settings panel
+    });
+
+    it("should remove inert from controls and settings when toolbar is expanded", async () => {
+      render(<PageFeedbackToolbarCSS />);
+      const toolbar = document.querySelector("[data-feedback-toolbar]");
+      const trigger = toolbar?.querySelector('[role="button"]');
+      expect(trigger).toBeTruthy();
+      fireEvent.click(trigger!);
+      await waitFor(() => {
+        const inertElements = toolbar?.querySelectorAll("[inert]") ?? [];
+        expect(inertElements.length).toBe(0);
+      });
+    });
+  });
+
+  describe("keyboard trigger", () => {
+    it("should expose trigger as button (role, tabIndex, title) when collapsed", () => {
+      render(<PageFeedbackToolbarCSS />);
+      const toolbar = document.querySelector("[data-feedback-toolbar]");
+      const trigger = toolbar?.firstElementChild as HTMLElement | null; // toolbar container is the trigger
+      expect(trigger).toBeTruthy();
+      expect(trigger?.getAttribute("role")).toBe("button");
+      expect(trigger?.getAttribute("tabindex")).toBe("0");
+      expect(trigger?.getAttribute("title")).toBe("Start feedback mode");
+    });
+
+    it("should activate toolbar on Enter when trigger is focused", async () => {
+      render(<PageFeedbackToolbarCSS />);
+      const toolbar = document.querySelector("[data-feedback-toolbar]");
+      const trigger = toolbar?.firstElementChild as HTMLElement | null; // toolbar container is the trigger
+      expect(trigger?.getAttribute("role")).toBe("button");
+      trigger?.focus();
+      fireEvent.keyDown(trigger!, { key: "Enter" });
+      await waitFor(() => {
+        expect(trigger?.getAttribute("role")).toBeNull();
+        expect(trigger?.getAttribute("tabindex")).toBe("-1");
+      });
+    });
+
+    it("should activate toolbar on Space when trigger is focused", async () => {
+      render(<PageFeedbackToolbarCSS />);
+      const toolbar = document.querySelector("[data-feedback-toolbar]");
+      const trigger = toolbar?.firstElementChild as HTMLElement | null; // toolbar container is the trigger
+      expect(trigger?.getAttribute("role")).toBe("button");
+      trigger?.focus();
+      fireEvent.keyDown(trigger!, { key: " " });
+      await waitFor(() => {
+        expect(trigger?.getAttribute("role")).toBeNull();
+        expect(trigger?.getAttribute("tabindex")).toBe("-1");
+      });
+    });
+
+    it("should not activate on key repeat (Enter)", () => {
+      render(<PageFeedbackToolbarCSS />);
+      const toolbar = document.querySelector("[data-feedback-toolbar]");
+      const trigger = toolbar?.firstElementChild as HTMLElement | null;
+      trigger?.focus();
+      fireEvent.keyDown(trigger!, { key: "Enter", repeat: true });
+      expect(trigger?.getAttribute("role")).toBe("button");
+    });
+
+    it("should not activate on key repeat (Space)", () => {
+      render(<PageFeedbackToolbarCSS />);
+      const toolbar = document.querySelector("[data-feedback-toolbar]");
+      const trigger = toolbar?.firstElementChild as HTMLElement | null;
+      trigger?.focus();
+      fireEvent.keyDown(trigger!, { key: " ", repeat: true });
+      expect(trigger?.getAttribute("role")).toBe("button");
+    });
+  });
 });
 
 describe("Annotation type", () => {

--- a/package/src/components/page-toolbar-css/index.tsx
+++ b/package/src/components/page-toolbar-css/index.tsx
@@ -2985,6 +2985,19 @@ export function PageFeedbackToolbarCSS({
               : undefined
           }
           onMouseDown={handleToolbarMouseDown}
+          onKeyDown={
+            !isActive
+              ? (e) => {
+                  // Ignore key repeats
+                  if (e.repeat) return;
+                  // Activate on Enter or Space (standard button activation keys)
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    setIsActive(true);
+                  }
+                }
+              : undefined
+          }
           role={!isActive ? "button" : undefined}
           tabIndex={!isActive ? 0 : -1}
           title={!isActive ? "Start feedback mode" : undefined}
@@ -3018,6 +3031,7 @@ export function PageFeedbackToolbarCSS({
                 : ""
             } ${tooltipsHidden || showSettings ? styles.tooltipsHidden : ""}`}
             onMouseLeave={showTooltipsAgain}
+            {...({ inert: !isActive ? '' : null } as React.HTMLAttributes<HTMLDivElement>)}
           >
             <div
               className={`${styles.buttonWrapper} ${
@@ -3206,6 +3220,7 @@ export function PageFeedbackToolbarCSS({
                   }
                 : undefined
             }
+            {...({ inert: !isActive ? '' : null } as React.HTMLAttributes<HTMLDivElement>)}
           >
             <div
               className={`${styles.settingsPanelContainer} ${isTransitioning ? styles.transitioning : ""}`}


### PR DESCRIPTION
Couple of small keyboard interaction improvements:

- Ensure nested button elements are not focusable unless the toolbar is active.
  - Uses `inert` attribute to prevent interactions.
- Allow opening via keyboard.
  - Since the trigger element is not actual button element, we were missing opening via <kbd>space</kbd> or <kbd>enter</kbd> 