### PR TITLE
Support *.localhost in local host detection

### DIFF
--- a/package/src/components/page-toolbar-css/index.tsx
+++ b/package/src/components/page-toolbar-css/index.tsx
@@ -662,7 +662,8 @@ export function PageFeedbackToolbarCSS({
     (window.location.hostname === "localhost" ||
       window.location.hostname === "127.0.0.1" ||
       window.location.hostname === "0.0.0.0" ||
-      window.location.hostname.endsWith(".local"));
+      window.location.hostname.endsWith(".local") ||
+      window.location.hostname.endsWith(".localhost"));
 
   // Effective React mode - derived from outputDetail when enabled
   const effectiveReactMode: ReactComponentMode =


### PR DESCRIPTION
## Summary
Expand local hostname detection to include `*.localhost` hosts in addition to `.local`. to enable React Component names on subdomain apps on localhost.

## Why
I ran into this while using a service like [Portless](https://github.com/vercel-labs/portless), which helps set up apps on subdomains of `.localhost`. The current check misses those hosts, so local behavior does not trigger as expected.

Per [RFC 6761, Section 6.3](https://datatracker.ietf.org/doc/html/rfc6761#section-6.3), `.localhost` is a special-use domain and that applies to names under it (for example, `app.localhost`), not just bare `localhost`.