### PR TITLE
Improve skill descriptions and content structure

### DIFF
--- a/skills/agentation-self-driving/SKILL.md
+++ b/skills/agentation-self-driving/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentation-self-driving
-description: Autonomous design critique mode using the Agentation annotation toolbar. Use when the user asks to "critique this page," "add design annotations," "review the UI," "self-driving mode," "auto-annotate," or wants an AI agent to autonomously add design feedback annotations to a web page via the browser. Requires the Agentation toolbar to be installed on the target page and agent-browser skill to be available.
+description: Autonomously critique a web page by scanning layout, typography, spacing, and CTA placement, then adding design annotations via the Agentation toolbar in a headed browser. Use when the user asks to "critique this page," "add design annotations," "review the UI," "self-driving mode," or "auto-annotate." Opens a visible browser, scrolls through sections, identifies hierarchy and grouping issues, and submits actionable feedback per element. Requires Agentation toolbar and agent-browser skill.
 allowed-tools: Bash(agent-browser:*)
 ---
 
@@ -163,38 +163,12 @@ ln -s "$(pwd)/skills/agentation-self-driving" ~/.claude/skills/agentation-self-d
 
 Restart Claude Code after installing. Verify with `/agentation-self-driving` — if it loads the skill instructions, the symlink is working.
 
-## Troubleshooting
+## Troubleshooting & Pitfalls
 
-- **"Browser not launched. Call launch first."**: Stale session from a previous run — run `agent-browser close 2>/dev/null` then retry the `--headed open` command
-- **Toolbar not found on page**: Agentation isn't installed — run `/agentation` to set it up first
-- **No dialog after clicking**: Toolbar collapsed — re-expand with the state-aware eval (check `[class*=expanded]` first), retry
-- **Wrong element targeted**: Click Cancel, scroll to intended element, retry with correct coordinates
-- **Add button stays disabled**: Text wasn't filled — re-snapshot and fill the textbox
-- **Page navigated**: "Block page interactions" is off — enable via toolbar settings
-- **Annotation count didn't increase**: Submission failed — dialog may still be open, re-snapshot and check
-- **Interrupted mid-run (Ctrl+C)**: The browser stays open with whatever state it was in. Run `agent-browser close` to clean up before starting a new session
+See [references/troubleshooting.md](references/troubleshooting.md) for common issues and agent-browser pitfalls.
 
-## agent-browser Pitfalls
+**Key rule**: `@ref` works for interaction commands (`click`, `fill`, `type`, `hover`). For everything else (`eval`, `get`, `scrollintoview`), use CSS selectors via `querySelector` in an eval.
 
-These will silently break the workflow if you're not aware of them:
+## Two-Session Workflow
 
-| Pitfall | What happens | Fix |
-|---------|-------------|-----|
-| `scrollintoview @ref` | Crashes: "Unsupported token @ref while parsing css selector" | Use `eval "document.querySelector('sel').scrollIntoView({block:'center'})"` |
-| `get box @ref` | Same crash — `get box` parses refs as CSS selectors | Use `eval "((r)=>r.x+','+r.y+','+r.width+','+r.height)(document.querySelector('sel').getBoundingClientRect())"` |
-| `eval` with double-bang | Bash expands double-bang as history substitution before the command runs | Use `expr !== null` or `expr ? true : false` instead |
-| `eval` with backslash-escaped quotes | Escaped inner quotes break across shells | Drop the quotes: `[class*=toggleContent]` works for simple values without spaces |
-| `snapshot -i \| head -50` | Annotation dialog refs (`textbox "What should change?"`, `Add`, `Cancel`) appear at the BOTTOM of the snapshot | Always read the **full** snapshot output — never truncate |
-| `click @ref` on overlay elements | The click goes through to the real DOM, bypassing the Agentation overlay | Use `mouse move` → `mouse down left` → `mouse up left` for coordinate-based clicks that the overlay intercepts |
-| `--headed open` fails with "Browser not launched" | Stale sessions from previous runs block new launches | Run `agent-browser close 2>/dev/null` then retry the open command |
-
-**Rule of thumb**: `@ref` works for interaction commands (`click`, `fill`, `type`, `hover`). For everything else (`eval`, `get`, `scrollintoview`), use CSS selectors via `querySelector` in an eval.
-
-## Two-Session Workflow (Full Self-Driving)
-
-With MCP connected (toolbar shows "MCP Connected"), annotations auto-send to any listening agent. This enables:
-
-- **Session 1** (this skill): Watches the page, adds critique annotations in the visible browser
-- **Session 2**: Runs `agentation_watch_annotations` in a loop, receives annotations, edits code to address each one
-
-The user watches Session 1 drive through the page in the browser while Session 2 fixes issues in the codebase — fully autonomous design review and implementation.
+With MCP connected, one agent critiques while another fixes code in real time. See [references/two-session-workflow.md](references/two-session-workflow.md) for full setup.

--- a/skills/agentation-self-driving/references/troubleshooting.md
+++ b/skills/agentation-self-driving/references/troubleshooting.md
@@ -1,0 +1,28 @@
+# Troubleshooting & agent-browser Pitfalls
+
+## Common Issues
+
+- **"Browser not launched. Call launch first."**: Stale session from a previous run — run `agent-browser close 2>/dev/null` then retry the `--headed open` command
+- **Toolbar not found on page**: Agentation isn't installed — run `/agentation` to set it up first
+- **No dialog after clicking**: Toolbar collapsed — re-expand with the state-aware eval (check `[class*=expanded]` first), retry
+- **Wrong element targeted**: Click Cancel, scroll to intended element, retry with correct coordinates
+- **Add button stays disabled**: Text wasn't filled — re-snapshot and fill the textbox
+- **Page navigated**: "Block page interactions" is off — enable via toolbar settings
+- **Annotation count didn't increase**: Submission failed — dialog may still be open, re-snapshot and check
+- **Interrupted mid-run (Ctrl+C)**: The browser stays open with whatever state it was in. Run `agent-browser close` to clean up before starting a new session
+
+## agent-browser Pitfalls
+
+These will silently break the workflow if you're not aware of them:
+
+| Pitfall | What happens | Fix |
+|---------|-------------|-----|
+| `scrollintoview @ref` | Crashes: "Unsupported token @ref while parsing css selector" | Use `eval "document.querySelector('sel').scrollIntoView({block:'center'})"` |
+| `get box @ref` | Same crash — `get box` parses refs as CSS selectors | Use `eval "((r)=>r.x+','+r.y+','+r.width+','+r.height)(document.querySelector('sel').getBoundingClientRect())"` |
+| `eval` with double-bang | Bash expands double-bang as history substitution before the command runs | Use `expr !== null` or `expr ? true : false` instead |
+| `eval` with backslash-escaped quotes | Escaped inner quotes break across shells | Drop the quotes: `[class*=toggleContent]` works for simple values without spaces |
+| `snapshot -i \| head -50` | Annotation dialog refs (`textbox "What should change?"`, `Add`, `Cancel`) appear at the BOTTOM of the snapshot | Always read the **full** snapshot output — never truncate |
+| `click @ref` on overlay elements | The click goes through to the real DOM, bypassing the Agentation overlay | Use `mouse move` → `mouse down left` → `mouse up left` for coordinate-based clicks that the overlay intercepts |
+| `--headed open` fails with "Browser not launched" | Stale sessions from previous runs block new launches | Run `agent-browser close 2>/dev/null` then retry the open command |
+
+**Rule of thumb**: `@ref` works for interaction commands (`click`, `fill`, `type`, `hover`). For everything else (`eval`, `get`, `scrollintoview`), use CSS selectors via `querySelector` in an eval.

--- a/skills/agentation/SKILL.md
+++ b/skills/agentation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: agentation
-description: Add Agentation visual feedback toolbar to a Next.js project
+description: Install and configure the Agentation annotation toolbar in a Next.js or React project. Use when the user wants to add design feedback tools, page annotation capabilities, or a visual critique overlay. Detects App Router vs Pages Router, installs the package, adds the component, and recommends MCP server setup for AI agent integration.
 ---
 
 # Agentation Setup
@@ -43,19 +43,13 @@ Set up the Agentation annotation toolbar in this project.
    - Tell the user the Agentation toolbar component is configured
 
 6. **Recommend MCP server setup**
-   - Explain that for real-time annotation syncing with AI agents, they should also set up the MCP server
-   - Recommend one of the following approaches:
-     - **Universal (supports 9+ agents including Claude Code, Cursor, Codex, Windsurf, etc.):**
-       See [add-mcp](https://github.com/neondatabase/add-mcp) — run `npx add-mcp` and follow the prompts to add `agentation-mcp` as an MCP server
-     - **Claude Code only (interactive wizard):**
-       Run `agentation-mcp init` after installing the package
-   - Tell user to restart their coding agent after MCP setup to load the server
-   - Explain that once configured, annotations will sync to the agent automatically
+   - For real-time annotation syncing with AI agents, recommend MCP server setup:
+     - **Universal (9+ agents — Claude Code, Cursor, Codex, Windsurf, etc.):** `npx add-mcp` → add `agentation-mcp`
+     - **Claude Code only:** `agentation-mcp init`
+   - Tell user to restart their coding agent after MCP setup
+   - Run `agentation-mcp doctor` to verify setup
 
 ## Notes
 
 - The `NODE_ENV` check ensures Agentation only loads in development
-- Agentation requires React 18
-- The MCP server runs on port 4747 by default for the HTTP server
-- MCP server exposes tools like `agentation_get_all_pending`, `agentation_resolve`, and `agentation_watch_annotations`
-- Run `agentation-mcp doctor` to verify setup after installing
+- Agentation requires React 18+


### PR DESCRIPTION
👋  hullo @benjitaylor 

This PR optimizes your skills based on `tessl skill review` feedback. Here's a summary of the results, with the actual changes listed below.

| Skill | Metric | Before | After |
|-------|--------|--------|-------|
| agentation | Description | 40% | 100% |
| agentation | Content | 92% | 100% |
| agentation | Average | 66% | 100% |
| agentation-self-driving | Description | 90% | 100% | | agentation-self-driving | Content | 77% | 85% |
| agentation-self-driving | Average | 77% | 93% |

agentation:
- Added "Use when..." clause with trigger terms (React, design feedback, annotation)
- Listed concrete actions (detect router, install, configure, recommend MCP)
- Tightened MCP setup instructions and trimmed redundant notes

agentation-self-driving:
- Added specific critique actions (layout, typography, spacing, CTA placement)
- Extracted troubleshooting and agent-browser pitfalls to references/troubleshooting.md
- Replaced inline two-session workflow with reference link (already in references/)
- Improved progressive disclosure: core workflow stays in SKILL.md, details in references

These were pretty straightforward changes to bring the skill in line with what performs well against Anthropic's best practices. Full disclosure, I work at @tesslio where we build tooling around this. Not a pitch, just fixes that were straightforward to make, so I thought I'd offer them as a PR.

Once merged, click [here](https://tessl.io/registry/skills/github/benjitaylor/agentation) to see the evals and iterate some more, otherwise I'm happy to offer more improvements as I find them.

Thanks in advance!