### PR TITLE
Add formatted description to webhook + http/mcp annotation events

### DIFF
--- a/package/src/components/page-toolbar-css/index.tsx
+++ b/package/src/components/page-toolbar-css/index.tsx
@@ -3755,7 +3755,8 @@ export function PageFeedbackToolbarCSS({
 
       // Sync to server (non-blocking, but update local ID with server's ID)
       if (endpoint && currentSessionId) {
-        syncAnnotation(endpoint, currentSessionId, newAnnotation)
+        const syncDescription = formatSingleAnnotation(newAnnotation, annotationsRef.current.length, "standard");
+        syncAnnotation(endpoint, currentSessionId, { ...newAnnotation, description: syncDescription })
           .then((serverAnnotation) => {
             // Update local annotation with server-assigned ID
             if (serverAnnotation.id !== newAnnotation.id) {
@@ -4040,6 +4041,7 @@ export function PageFeedbackToolbarCSS({
       if (endpoint) {
         updateAnnotationOnServer(endpoint, editingAnnotation.id, {
           comment: newComment,
+          description,
         }).catch((error) => {
           console.warn(
             "[Agentation] Failed to update annotation on server:",

--- a/package/src/types.ts
+++ b/package/src/types.ts
@@ -31,6 +31,9 @@ export type Annotation = {
   strokeId?: string; // Unique ID of linked drawing stroke
   drawingContext?: DrawingContext; // Rich gesture + element data for drawings
 
+  // Formatted markdown description (added for webhooks and server sync)
+  description?: string;
+
   // Protocol fields (added when syncing to server)
   sessionId?: string;
   url?: string;


### PR DESCRIPTION
Webhook events now include a description field with the same markdown output as clipboard copy. Also fixes the submit event to include standalone stroke descriptions that were previously only in the copy output.

Example webhook raw response:

```
{
  "event": "annotation.add",
  "timestamp": 1772069408193,
  "url": "http://agentation.localhost:1355/",
  "annotation": {
    "id": "1772069408193",
    "x": 52.182539682539684,
    "y": 2667.5,
    "comment": "Underline this",
    "element": "Line: \"Made by Benji Taylor, Dennis Jin, and Al\"",
    "elementPath": ".main-content > .footer",
    "timestamp": 1772069408193,
    "boundingBox": {
      "x": 468,
      "y": 2631.921875,
      "width": 576,
      "height": 79.5
    },
    "nearbyText": "Made by Benji Taylor, Dennis Jin, and Alex VanderzonColophon",
    "cssClasses": "footer",
    "isFixed": false,
    "fullPath": "body > main.main-content > footer.footer",
    "accessibility": "",
    "computedStyles": "color: rgba(0, 0, 0, 0.4); border-color: rgba(0, 0, 0, 0.06) rgba(0, 0, 0, 0.4) rgba(0, 0, 0, 0.4); font-size: 12px; font-weight: 400; font-family: Inter, system-ui, -apple-system,
\"system-ui\", \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif; text-align: left; width: 576px; height: 79.5px; padding: 16px 24px 48px; margin: 0px 468px; display: flex; flex-direction:
row; justify-content: space-between; align-items: center; opacity: 1",
    "nearbyElements": "article.article, div",
    "drawingIndex": 6,
    "strokeId": "a7fcfbb9-1e9a-4726-9d09-3375005b9e96",
    "drawingContext": {
      "gesture": "Line",
      "strokeBBox": {
        "x": 486,
        "y": 818,
        "width": 303,
        "height": 4
      },
      "strokeStart": {
        "x": 486,
        "y": 822
      },
      "strokeEnd": {
        "x": 789,
        "y": 819
      },
      "primary": {
        "name": "footer",
        "path": ".main-content > .footer",
        "boundingBox": {
          "x": 468,
          "y": 783,
          "width": 576,
          "height": 80
        },
        "nearbyText": "Made by Benji Taylor, Dennis Jin, and Alex VanderzonColophon",
        "cssClasses": "footer",
        "computedStyles": "color: rgba(0, 0, 0, 0.4); border-color: rgba(0, 0, 0, 0.06) rgba(0, 0, 0, 0.4) rgba(0, 0, 0, 0.4); font-size: 12px; font-weight: 400; font-family: Inter, system-ui,
-apple-system, \"system-ui\", \"Segoe UI\", Roboto, \"Helvetica Neue\", Arial, sans-serif; text-align: left; width: 576px; height: 79.5px; padding: 16px 24px 48px; margin: 0px 468px; display: flex;
flex-direction: row; justify-content: space-between; align-items: center; opacity: 1",
        "accessibility": ""
      },
      "textContent": "Vanderzon",
      "screenshot": "data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/4gHYSUNDX1BST0ZJTEUAAQEAAAHIAAAAAAQwAABtbnRyUkdCIFhZWiAH4AABAAEAAAAAAABhY3NwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAQAA9tYAAQAAAADTLQA
AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAlkZXNjAAAA8AAAACRyWFlaAAABFAAAABRnWFlaAAABKAAAABRiWFlaAAABPAAAABR3dHB0AAABUAAAABRyVFJDAAABZAAAAChnVFJDAAABZAAAAChiVFJDAAABZAAAAChjcHJ0AA
ABjAAAADxtbHVjAAAAAAAAAAEAAAAMZW5VUwAAAAgAAAAcAHMAUgBHAEJYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9YWVogAAAAAAAA9tYAAQAAAADTLXBhcmEAAAAAAAQAAAACZmYAAPKnAAANWQAAE9AAA
ApbAAAAAAAAAABtbHVjAAAAAAAAAAEAAAAMZW5VUwAAACAAAAAcAEcAbwBvAGcAbABlACAASQBuAGMALgAgADIAMAAxADb/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/2wBDAQMDAwQDBAgE
BAgQCwkLEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBD/wAARCABEAW8DASIAAhEBAxEB/8QAHQABAAICAwEBAAAAAAAAAAAAAAMHBAUBAgYICf/EAD0QAAEEAQICCAMECQMFAAAAAAEAAgMEBQYREiEHExQoMUFnoyIyMxVhc7I
IFhcjUVdxlNE0YoE3QlR1s//EABkBAQADAQEAAAAAAAAAAAAAAAABAwQFAv/EAC4RAQABAwIFAgUDBQAAAAAAAAABAgMVkuEEBRJjZBFxITFBctEGobEyUWKRwf/aAAwDAQACEQMRAD8A/VNRWfpj8Rn5gpVFZ+mPxGfmCCVERARRWbNenXluXLEcEEDHSSyyPDWRsaNy5x
PIAAEklQT5nD1ca3M2crThx72se21JO1sJa/YMIeTw7O3Gx357jZBmIiiltVYJYYJ7MUcll5jhY94DpXBpcWtB+YhrXHYeQJ8kEqIoorVWeWaCGzFJLWcGTMa8F0bi0OAcB4EtIPPyIKCVEWozWsNJabnhrai1TiMVNYHFDHdvRQOkG+27Q9wJ58uSDbousckc0bZYpGvY9
oc1zTuHA+BB8wuyAi10Oo8BYuNx8GapSWXzTV2wtnaXmWIAysA334mgjiHlvzWDltf6DwF5+MzutsDjbkYDn17eShhlaCNwS1zgRuOfgg36KGpbq36sN+hZis1rMbZoZoXh7JGOG7XNcORBBBBHIgpcu08dUmv5C3DVq143SzTTSBkcbGjcuc48gAOZJQTIuPHmFygItRmd
X6T07Ygqag1PicZPZG8MVy7FA+Ub7fCHuBdz5cltIpYp42TQyNkjkaHMe07hwPgQR4hB3REQEWNSyWPyPXmhdhsdmmfWm6p4d1crfmY7bwcN+YWSgIsA5/Biyyl9sUu0SWXUmxCdpcbDY+sMW2+/GGfFw+O3PwWegIiICIiAiwIs/gZ8e7LwZuhJRY8xOtNssMTXh/AWl4O
wId8O2/jy8VnoCIsaLJ42eOzLBkK0jKb3xWHMlaRC9o3c15B+EgEEg+CDJRRVbVW9Vhu0rMVivYjbLDNE8PZIxw3a5rhyIIIII8VKgIoHXabLjMc63CLcsT52QGQdY6NpaHPDfEtBewE+ALm/xCnQEREBERAREQFFZ+mPxGfmClUVn6Y/EZ+YIJUREHnOkf8A6eao/wDTXf
8A4PVTanr3X6byOgJopBR0tDPkxIR8MkD2g049/PhMko/rWH8VfiIKiv6otDpHrw08tNE8ZtlCWpPlnF7oSzY7Ums4GxHcObK53ESRz57LCxWTF3UmkZ5NQ3LmonXL78jjZrBdHWnFSyAzqzyh2O7W7AcTdz8W24unYb77Df8Aimw3328UFTdF2Zz+SzlQ3dQV7EkuOfJlK
Ryc1qaOxuzYuhdC1lRzXF7erDtjvyDuHiWHqTJQY7VWs5ampLtTOR2KT8TQinLG25+zQjh6scpuI8LXAg8LSD8O+6uXYDmB4psDz28EFdw3s47XX6iOv3OCC8/Oun6x27seW/BCXfw7Q5zeHf5I9vBaPpPykeL6SKhk1pgdN9fpyxEJsvUFiOUmwz4GNMjPi8/+7kDyKtCj
gqFDJ3cxGZpLl8MbJJLKX8MbS4tjYDya0FzjsPMlbFB82W83nsZprSeKOSbpvERaYaaktzOz4vrLjHlnEHMrvMzgxsb2wuA3Eh+B22w3+Us6rfR1HqO9q3KRZHAU8PZihp2ZIqnaHQsdPvE4N4mPO44XtGw58LXbq8yAfEA+a5QVVgMvlZtc06suSsvhdnc9EY3SuLSyNkf
A3bfwbudh5brfdIsMTs5oJzomEu1OASWjmPs+6vS4DT+N03SfRxjZuGWeW1K+aV0skksji573OcSSST/wNgOQWyQULY1ZcudKNbG0M9crCxn7GIt0pM882G1xBK3dtFkYjgi4msfHMXdYd2nc7rHyWW1NqHQes6mau3SNG6Wv4S8XOc1l7IkPDpnDwf8AuYoZAT/5R819AF
oO+3IuG248VrNO6bxul6MlHG9e/r532Z5rEzpZp5n/ADPe9x3J5AfcAANgAgqnKaivRanugaqyUeqYdRU6mOwTbDhDNjXPhD3dn8JGGJ0z3TEEscCA4cOy9j0U17VjHZPPZDM5O9YtZjKVwyzbfJFDFDfnjjZGwnhbs1o57b7bDfYAD3Ow3325rlBWmqtQaU0/0s05tWZKh
Tgsabnii7W5oEru0xksaD8xIHyjmdl4S7fzuEwWAqRzjA6XyF7M2oDcy82FZFCbAdSidOyJ7ogY3yPZEQ0EBrSfh4XfQy4IBGxAI+9BQwfqvNY+3Nk9c5VtjGaGhycMuNtywxTWhLa4LDg5kbnktiZuHMa1253aQG7ZN2/qC2NSav8A1qzEM+Jv4N1WrFbc2q0S16jpmuiH
wva/rXbh24B5t2JJN4ogoTWGortWCzNd1i+jXgz+Xaa0uXmxpssYI+BkVprXBr2bkthdsJOI8iGlWm/WFPCaJxeqcnBkuyTQ0jYfYjaJ67JuBplnA2DeHiBk2HLZx22C9OQDyIB8+a5QUdDmLLrIzWEyMrcfm9YZOavPBIQy1AzCzAPBHzM62HcHwJYCPIrc9Gz8vRzumIb
WpMtkmag0ecpcbetOmb2qN9QB8Yd9PcWHghuwOwJ3PNWv4cguUBERAXmOkrUNzTWislkMVGZcpMxtLGxAjeS5O4RQNG/+97SfuB8F6dEHzu2tktF4DUWgcnghia1mrjsljIhbbYD+qlr17J4gBseJsLyP4yuO/NbAaj1ZL0my1repaVC3FqI1m4+fN2GvkxYPLhoNrlhDov
3gnL+T/F7QC1XwuNhvvsN/DdBUXRLncpk9VXK2Xz2SsY9lSQ6XNl7gMlQ69wfZeeI9dI09UwOcAerLH7fvSTD0gQ3sXqrJaMxwkZF0mxwRRvYCOqmjLYrz9x4E0+Bw++Mq5EQUPb1XNT6UaOOxGYmqiDPw4l+Omzby/svVcJDccyMRsg+VzZnuLydtjz2XfEXNX4zEaf1Di
9RZnKZXNUcwx1W3adNDLLFFLJXDYzuGua6NrdwN3Ani3V6bDfi2G55brGflMZG90cmRqtc0kOaZmggjyPNTFM1fKETMR83z3BmwzMT5To+1fk9SZeHQOSnPabDrT4LvXVC4AEHgk5AmADZpa34Bxc56Ga1BcxeQgxmvGTUZ8hgK/WY7UFjJT1pZr7I5T2iSCMM443AGHc8O
3NrQ7ZXFnOkjo+0vLFXz+s8Nj5Z2l7GT3I2uc3fbfbfw381rB039Dw8OknTo8/8AXR/5Wujl3GXaYrotVTE/WKZ/Ciri+HonpqriJ94eN1Pe0vV6ScPo6LpGyeImxorWci63qWdnXtHKGqyN8m0kkp2c9xBPD4/E8EdMdqO+/UFTh1XkpdUzZ27WyeEdYcYq+PaZwx3Z/CN
gjbC9swALy4DiPFsPa/tw6H/5lae/v4/8rb6f6QNC6rkkZprV2HyUkZDXsrXI3vbv4btB35nw/wCUucv4u1TNdy1VER9ZpmI/hNHFWLk9NNcTPvCv+jCfM1Lugp7epsxkv1o0lNevx3rbpmdfGKZY9gd8h2ne07fNyLtzzVwoixrxERAUVn6Y/EZ+YKVRWfpj8Rn5gglWJl
/tb7Ju/YPZPtPs8nYu2cXUdfwnq+s4Pi4OLbi4ee2+3NZaL1TPTMSiY9Y9FId8D0899O+B6ee+rvRdvO+NZ0bubje9c1bKQ74Hp576d8D0899XeiZ3xrOjcxveuatlId8D0899O+B6ee+rvRM741nRuY3vXNWykO+B6ee+nfA9PPfV3omd8azo3Mb3rmrZSHfA9PPfTvgen
nvq70TO+NZ0bmN71zVspDvgennvp3wPTz31d6JnfGs6NzG965q2Uh3wPTz3074Hp576u9EzvjWdG5je9c1bKQ74Hp576d8D0899XeiZ3xrOjcxveuatlId8D0899O+B6ee+rvRM741nRuY3vXNWykO+B6ee+nfA9PPfV3omd8azo3Mb3rmrZSHfA9PPfTvgennvq70TO+NZ
0bmN71zVspDvgennvp3wPTz31d6JnfGs6NzG965q2Uh3wPTz3074Hp576u9EzvjWdG5je9c1bKQ74Hp576d8D0899XeiZ3xrOjcxveuatlId8D0899O+B6ee+rvRM741nRuY3vXNWykO+B6ee+oH6I/Sf1na6jVPSXh9KUI2AH7AgdJLM7i38XcLm+AG4ft/tO5V7Ipjn9y
j42rFqmr6TFuJmPb19Y/YnldNXwru1zH9uqf+ek/uo9n6LOPusazU/SvrzLtIDpY5MntHJL5u2cHEc9ztuT9588tn6I3Qc1jWu07ceQAC45Gfc/ednbK5UXmr9S83n+niKqftnpj/AFT6Jjk/AR87UT7/AB/n1Vpgv0b+hbARSxV9CUbXXODi6/xWnDYeDTITwj+i2f7D+h
/+Wunv7CP/AAvcIslfOOY3Kprrv1zM/wCVX5X08BwlEdNNqmI9oeH/AGH9D/8ALXT39hH/AIWrzX6NnQnnXwPtaDpVzAeXYpJKoePMOETmh39TzHkQrMRKOccxtVdVF+uJ+6r8lXAcJXHTVapmPtj8CIi5zWIiICis/TH4jPzBSqKz9MfiM/MEEqIiAiIgIiICIiAiIgIiI
CIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAorP0x+Iz8wREEqIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiAiIgIiICIiD//2Q=="
    },
    "sessionId": "mm2qt5uf-rxj88m",
    "url": "http://agentation.localhost:1355/",
    "status": "pending"
  },
  "description": "### 7. Line: \"Made by Benji Taylor, Dennis Jin, and Al\"\n**Gesture:** Line drawn near \"Vanderzon\"\n**Target text:** \"Vanderzon\"\n**In:**\n  - **footer**\n    Content: \"Made by
Benji Taylor, Dennis Jin, and Alex VanderzonColophon\"\n    Classes: `footer`\n**Feedback:** Underline this\n\n"
}

```

Screenshot (4KB):

![output](https://github.com/user-attachments/assets/ccd53ca2-08f9-4620-891d-47f14e0ff363)


## Drawing Output Channels                                                                                                                                                                                         
                                     
| Channel | Drawing Annotations | Screenshots | Formatted Markdown |                                                                                                                                               
|---------|:--:|:--:|:--:|                                                                                                                                                                                         
| **Copy (clipboard)** | Full | Composited PNG saved to disk | Yes |                                                                                                                                               
| **HTTP/MCP sync** | Full (raw JSON) | In JSON (data URL) | Yes (`description` field) |                                                                                                                           
| **Webhooks** | Full (raw JSON) | In JSON (data URL) | Yes (`description` field) |                                                                                                                                

### Notes

- **Copy** targets humans — formatted markdown for readability, composited screenshot strip saved to disk for visual context.
- **HTTP/MCP** sends full annotation objects with `drawingContext` plus a `description` field with formatted markdown. Screenshots included as base64 on `drawingContext.screenshot`.
- **Webhooks** bridge both worlds — raw JSON plus formatted `description` for individual events, and complete markdown output on submit. Screenshots included as base64 on `drawingContext.screenshot`.
- **Screenshots** are captured client-side as base64 JPEG and included in all channels via `drawingContext.screenshot`. Copy additionally composites them into a numbered strip PNG and saves to disk.
