### PR TITLE
Add configurable activation shortcut setting

### DIFF
--- a/package/package.json
+++ b/package/package.json
@@ -25,6 +25,7 @@
   ],
   "scripts": {
     "build": "tsup",
+    "prepare": "pnpm build",
     "watch": "tsup --watch",
     "dev": "pnpm build && pnpm watch",
     "test": "vitest run",

--- a/package/src/components/page-toolbar-css/index.test.tsx
+++ b/package/src/components/page-toolbar-css/index.test.tsx
@@ -8,11 +8,30 @@ const mockClipboard = {
   writeText: vi.fn().mockResolvedValue(undefined),
 };
 
+const createLocalStorageMock = () => {
+  const store = new Map<string, string>();
+
+  return {
+    getItem: vi.fn((key: string) => store.get(key) ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(key, value);
+    }),
+    removeItem: vi.fn((key: string) => {
+      store.delete(key);
+    }),
+    clear: vi.fn(() => {
+      store.clear();
+    }),
+  };
+};
+
 beforeEach(() => {
   vi.stubGlobal("navigator", {
     clipboard: mockClipboard,
-    userAgent: "test-agent",
+    userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_0)",
+    platform: "MacIntel",
   });
+  vi.stubGlobal("localStorage", createLocalStorageMock());
   mockClipboard.writeText.mockClear();
 });
 
@@ -76,6 +95,71 @@ describe("PageFeedbackToolbarCSS", () => {
           />
         )
       ).not.toThrow();
+    });
+  });
+
+  describe("activation shortcut settings", () => {
+    it("captures and persists a custom activation shortcut from settings", async () => {
+      render(<PageFeedbackToolbarCSS />);
+
+      fireEvent.click(screen.getByTitle("Start feedback mode"));
+      fireEvent.click(screen.getByLabelText("Open settings"));
+
+      expect(screen.getByText("Activation Shortcut")).toBeTruthy();
+
+      const captureButton = screen.getByRole("button", {
+        name: "Set activation shortcut",
+      });
+
+      fireEvent.focus(captureButton);
+      fireEvent.keyDown(captureButton, {
+        key: "a",
+        metaKey: true,
+        shiftKey: true,
+      });
+
+      await waitFor(() => {
+        const raw = localStorage.getItem("feedback-toolbar-settings");
+        expect(raw).toBeTruthy();
+        expect(raw).toContain('"key":"A"');
+        expect(raw).toContain('"modifiers":["mod","shift"]');
+      });
+
+      expect(screen.getByText("Cmd + Shift + A")).toBeTruthy();
+    });
+
+    it("uses the stored activation shortcut instead of the default one", async () => {
+      localStorage.setItem(
+        "feedback-toolbar-settings",
+        JSON.stringify({
+          activationShortcut: {
+            key: "A",
+            modifiers: ["mod", "shift"],
+          },
+        }),
+      );
+
+      render(<PageFeedbackToolbarCSS />);
+
+      expect(screen.getByTitle("Start feedback mode")).toBeTruthy();
+
+      fireEvent.keyDown(document, {
+        key: "f",
+        metaKey: true,
+        shiftKey: true,
+      });
+
+      expect(screen.getByTitle("Start feedback mode")).toBeTruthy();
+
+      fireEvent.keyDown(document, {
+        key: "a",
+        metaKey: true,
+        shiftKey: true,
+      });
+
+      await waitFor(() => {
+        expect(screen.queryByTitle("Start feedback mode")).toBeNull();
+      });
     });
   });
 });

--- a/package/src/components/page-toolbar-css/index.tsx
+++ b/package/src/components/page-toolbar-css/index.tsx
@@ -83,6 +83,14 @@ import {
   originalSetTimeout,
   originalSetInterval,
 } from "../../utils/freeze-animations";
+import {
+  DEFAULT_ACTIVATION_SHORTCUT,
+  detectShortcutPlatform,
+  eventToActivationShortcut,
+  formatActivationShortcut,
+  matchesActivationShortcut,
+  type ActivationShortcut,
+} from "../../utils/activation-shortcut";
 
 import type { Annotation } from "../../types";
 import styles from "./styles.module.scss";
@@ -146,6 +154,7 @@ type ToolbarSettings = {
   outputDetail: OutputDetailLevel;
   autoClearAfterCopy: boolean;
   annotationColor: string;
+  activationShortcut: ActivationShortcut;
   blockInteractions: boolean;
   reactEnabled: boolean; // Simple toggle - mode derived from outputDetail
   markerClickBehavior: MarkerClickBehavior;
@@ -157,6 +166,7 @@ const DEFAULT_SETTINGS: ToolbarSettings = {
   outputDetail: "standard",
   autoClearAfterCopy: false,
   annotationColor: "#3c82f7",
+  activationShortcut: DEFAULT_ACTIVATION_SHORTCUT,
   blockInteractions: true,
   reactEnabled: true,
   markerClickBehavior: "edit",
@@ -581,6 +591,7 @@ export function PageFeedbackToolbarCSS({
   const [settingsPage, setSettingsPage] = useState<"main" | "automations">(
     "main",
   );
+  const [isCapturingShortcut, setIsCapturingShortcut] = useState(false);
   const [isTransitioning, setIsTransitioning] = useState(false);
   const [tooltipsHidden, setTooltipsHidden] = useState(false);
   const [tooltipSessionActive, setTooltipSessionActive] = useState(false);
@@ -738,6 +749,11 @@ export function PageFeedbackToolbarCSS({
   const [settings, setSettings] = useState<ToolbarSettings>(DEFAULT_SETTINGS);
   const [isDarkMode, setIsDarkMode] = useState(true);
   const [showEntranceAnimation, setShowEntranceAnimation] = useState(false);
+  const shortcutPlatform = detectShortcutPlatform();
+  const formattedActivationShortcut = formatActivationShortcut(
+    settings.activationShortcut,
+    shortcutPlatform,
+  );
 
   // Check if running in development mode - React detection only works in development mode
   const isDevMode = process.env.NODE_ENV === "development";
@@ -809,6 +825,7 @@ export function PageFeedbackToolbarCSS({
       setTooltipsHidden(false);
       // Reset to main page when settings close
       setSettingsPage("main");
+      setIsCapturingShortcut(false);
       const timer = originalSetTimeout(() => setShowSettingsVisible(false), 0);
       return () => clearTimeout(timer);
     }
@@ -2903,6 +2920,8 @@ export function PageFeedbackToolbarCSS({
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
+      if (isCapturingShortcut) return;
+
       // Don't trigger shortcuts when typing in inputs
       const target = e.target as HTMLElement;
       const isTyping =
@@ -2924,8 +2943,7 @@ export function PageFeedbackToolbarCSS({
         }
       }
 
-      // Cmd+Shift+F / Ctrl+Shift+F to toggle feedback mode
-      if ((e.metaKey || e.ctrlKey) && e.shiftKey && (e.key === "f" || e.key === "F")) {
+      if (matchesActivationShortcut(e, settings.activationShortcut)) {
         e.preventDefault();
         hideTooltipsUntilMouseLeave();
         setIsActive((prev) => !prev);
@@ -2991,6 +3009,8 @@ export function PageFeedbackToolbarCSS({
     isActive,
     pendingAnnotation,
     annotations.length,
+    isCapturingShortcut,
+    settings.activationShortcut,
     settings.webhookUrl,
     webhookUrl,
     sendState,
@@ -3155,6 +3175,7 @@ export function PageFeedbackToolbarCSS({
 
             <div className={styles.buttonWrapper}>
               <button
+                aria-label="Open settings"
                 className={`${styles.controlButton} ${!isDarkMode ? styles.light : ""}`}
                 onClick={(e) => {
                   e.stopPropagation();
@@ -3362,6 +3383,57 @@ export function PageFeedbackToolbarCSS({
                 </div>
 
                 <div className={styles.settingsSection}>
+                  <div className={styles.settingsRow}>
+                    <div
+                      className={`${styles.settingsLabel} ${!isDarkMode ? styles.light : ""}`}
+                    >
+                      Activation Shortcut
+                      <Tooltip content="Toggle Agentation on or off. Press a new combo with Cmd/Ctrl plus a key.">
+                        <span className={styles.helpIcon}>
+                          <IconHelp size={20} />
+                        </span>
+                      </Tooltip>
+                    </div>
+                    <button
+                      aria-label="Set activation shortcut"
+                      className={`${styles.cycleButton} ${!isDarkMode ? styles.light : ""}`}
+                      onBlur={() => setIsCapturingShortcut(false)}
+                      onClick={() => setIsCapturingShortcut(true)}
+                      onFocus={() => setIsCapturingShortcut(true)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Escape") {
+                          e.preventDefault();
+                          setIsCapturingShortcut(false);
+                          return;
+                        }
+
+                        const shortcut = eventToActivationShortcut(e.nativeEvent);
+                        if (!shortcut) return;
+
+                        e.preventDefault();
+                        setSettings((s) => ({
+                          ...s,
+                          activationShortcut: shortcut,
+                        }));
+                        setIsCapturingShortcut(false);
+                      }}
+                      type="button"
+                    >
+                      <span
+                        key={
+                          isCapturingShortcut
+                            ? "capturing"
+                            : formattedActivationShortcut
+                        }
+                        className={styles.cycleButtonText}
+                      >
+                        {isCapturingShortcut
+                          ? "Press shortcut..."
+                          : formattedActivationShortcut}
+                      </span>
+                    </button>
+                  </div>
+
                   <div className={styles.settingsRow}>
                     <div
                       className={`${styles.settingsLabel} ${!isDarkMode ? styles.light : ""}`}

--- a/package/src/utils/activation-shortcut.test.ts
+++ b/package/src/utils/activation-shortcut.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_ACTIVATION_SHORTCUT,
+  eventToActivationShortcut,
+  formatActivationShortcut,
+  matchesActivationShortcut,
+} from "./activation-shortcut";
+
+describe("activation-shortcut", () => {
+  it("formats the default shortcut for macOS", () => {
+    expect(formatActivationShortcut(DEFAULT_ACTIVATION_SHORTCUT, "mac")).toBe(
+      "Cmd + Shift + F",
+    );
+  });
+
+  it("captures a shortcut from a keyboard event", () => {
+    const shortcut = eventToActivationShortcut(
+      new KeyboardEvent("keydown", {
+        key: "a",
+        metaKey: true,
+        shiftKey: true,
+      }),
+      "mac",
+    );
+
+    expect(shortcut).toEqual({
+      key: "A",
+      modifiers: ["mod", "shift"],
+    });
+  });
+
+  it("matches the configured shortcut", () => {
+    const shortcut = {
+      key: "A",
+      modifiers: ["mod", "shift"] as const,
+    };
+
+    expect(
+      matchesActivationShortcut(
+        new KeyboardEvent("keydown", {
+          key: "a",
+          metaKey: true,
+          shiftKey: true,
+        }),
+        shortcut,
+        "mac",
+      ),
+    ).toBe(true);
+
+    expect(
+      matchesActivationShortcut(
+        new KeyboardEvent("keydown", {
+          key: "f",
+          metaKey: true,
+          shiftKey: true,
+        }),
+        shortcut,
+        "mac",
+      ),
+    ).toBe(false);
+  });
+});

--- a/package/src/utils/activation-shortcut.ts
+++ b/package/src/utils/activation-shortcut.ts
@@ -1,0 +1,129 @@
+export type ActivationShortcutModifier = "mod" | "shift" | "alt";
+export type ShortcutPlatform = "mac" | "other";
+
+export type ActivationShortcut = {
+  key: string;
+  modifiers: ActivationShortcutModifier[];
+};
+
+const MODIFIER_ORDER: ActivationShortcutModifier[] = ["mod", "shift", "alt"];
+const MODIFIER_KEYS = new Set([
+  "meta",
+  "os",
+  "control",
+  "ctrl",
+  "shift",
+  "alt",
+]);
+
+export const DEFAULT_ACTIVATION_SHORTCUT: ActivationShortcut = {
+  key: "F",
+  modifiers: ["mod", "shift"],
+};
+
+function normalizeKey(key: string): string | null {
+  const trimmedKey = key.trim();
+  if (!trimmedKey) return null;
+
+  const lowered = trimmedKey.toLowerCase();
+  if (MODIFIER_KEYS.has(lowered)) return null;
+
+  if (trimmedKey.length === 1) {
+    return trimmedKey.toUpperCase();
+  }
+
+  return trimmedKey.length <= 12
+    ? `${trimmedKey[0].toUpperCase()}${trimmedKey.slice(1)}`
+    : null;
+}
+
+function normalizeModifiers(
+  modifiers: ActivationShortcutModifier[],
+): ActivationShortcutModifier[] {
+  return MODIFIER_ORDER.filter((modifier) => modifiers.includes(modifier));
+}
+
+export function detectShortcutPlatform(): ShortcutPlatform {
+  if (typeof navigator === "undefined") return "other";
+
+  const platform =
+    navigator.platform ||
+    // navigator.userAgentData is not available in all environments yet.
+    navigator.userAgent ||
+    "";
+
+  return /mac/i.test(platform) ? "mac" : "other";
+}
+
+export function normalizeActivationShortcut(
+  shortcut: ActivationShortcut,
+): ActivationShortcut {
+  const key = normalizeKey(shortcut.key) ?? DEFAULT_ACTIVATION_SHORTCUT.key;
+
+  return {
+    key,
+    modifiers: normalizeModifiers(shortcut.modifiers),
+  };
+}
+
+function getPressedModifiers(event: Pick<KeyboardEvent, "metaKey" | "ctrlKey" | "shiftKey" | "altKey">): ActivationShortcutModifier[] {
+  const modifiers: ActivationShortcutModifier[] = [];
+
+  if (event.metaKey || event.ctrlKey) modifiers.push("mod");
+  if (event.shiftKey) modifiers.push("shift");
+  if (event.altKey) modifiers.push("alt");
+
+  return normalizeModifiers(modifiers);
+}
+
+export function eventToActivationShortcut(
+  event: Pick<KeyboardEvent, "key" | "metaKey" | "ctrlKey" | "shiftKey" | "altKey">,
+  _platform: ShortcutPlatform = detectShortcutPlatform(),
+): ActivationShortcut | null {
+  const key = normalizeKey(event.key);
+  if (!key) return null;
+
+  const modifiers = getPressedModifiers(event);
+  if (!modifiers.includes("mod")) return null;
+
+  return {
+    key,
+    modifiers,
+  };
+}
+
+export function matchesActivationShortcut(
+  event: Pick<KeyboardEvent, "key" | "metaKey" | "ctrlKey" | "shiftKey" | "altKey">,
+  shortcut: ActivationShortcut,
+  _platform: ShortcutPlatform = detectShortcutPlatform(),
+): boolean {
+  const normalizedShortcut = normalizeActivationShortcut(shortcut);
+  const eventShortcut = eventToActivationShortcut(event);
+
+  if (!eventShortcut) return false;
+
+  return (
+    eventShortcut.key === normalizedShortcut.key &&
+    eventShortcut.modifiers.length === normalizedShortcut.modifiers.length &&
+    eventShortcut.modifiers.every(
+      (modifier, index) => modifier === normalizedShortcut.modifiers[index],
+    )
+  );
+}
+
+export function formatActivationShortcut(
+  shortcut: ActivationShortcut,
+  platform: ShortcutPlatform = detectShortcutPlatform(),
+): string {
+  const normalizedShortcut = normalizeActivationShortcut(shortcut);
+  const labels: Record<ActivationShortcutModifier, string> = {
+    mod: platform === "mac" ? "Cmd" : "Ctrl",
+    shift: "Shift",
+    alt: platform === "mac" ? "Option" : "Alt",
+  };
+
+  return [
+    ...normalizedShortcut.modifiers.map((modifier) => labels[modifier]),
+    normalizedShortcut.key,
+  ].join(" + ");
+}


### PR DESCRIPTION
## Summary
- add a persisted activation shortcut setting inside the Agentation settings panel
- replace the hardcoded Cmd/Ctrl+Shift+F toggle logic with reusable shortcut parsing and matching helpers
- add coverage for shortcut parsing plus settings-panel capture/persistence

## Test Plan
- pnpm --dir package build
- pnpm --dir package test