### PR TITLE
Fix focus stolen when annotating inputs in modals/drawers

### DIFF
--- a/package/src/components/annotation-popup-css/index.tsx
+++ b/package/src/components/annotation-popup-css/index.tsx
@@ -6,6 +6,25 @@ import { IconTrash } from "../icons";
 import { originalSetTimeout } from "../../utils/freeze-animations";
 
 // =============================================================================
+// Helpers
+// =============================================================================
+
+/** Focus an element while temporarily blocking focus-trap libraries (e.g. Radix
+ *  FocusScope) from reclaiming focus via focusin/focusout handlers. */
+function focusBypassingTraps(el: HTMLElement | null) {
+  if (!el) return;
+  const trap = (e: Event) => e.stopImmediatePropagation();
+  document.addEventListener("focusin", trap, true);
+  document.addEventListener("focusout", trap, true);
+  try {
+    el.focus();
+  } finally {
+    document.removeEventListener("focusin", trap, true);
+    document.removeEventListener("focusout", trap, true);
+  }
+}
+
+// =============================================================================
 // Types
 // =============================================================================
 
@@ -99,7 +118,7 @@ export const AnnotationPopupCSS = forwardRef<AnnotationPopupCSSHandle, Annotatio
       const focusTimer = originalSetTimeout(() => {
         const textarea = textareaRef.current;
         if (textarea) {
-          textarea.focus();
+          focusBypassingTraps(textarea);
           textarea.selectionStart = textarea.selectionEnd = textarea.value.length;
           textarea.scrollTop = textarea.scrollHeight;
         }
@@ -118,7 +137,7 @@ export const AnnotationPopupCSS = forwardRef<AnnotationPopupCSSHandle, Annotatio
       setIsShaking(true);
       shakeTimerRef.current = originalSetTimeout(() => {
         setIsShaking(false);
-        textareaRef.current?.focus();
+        focusBypassingTraps(textareaRef.current);
       }, 250);
     }, []);
 
@@ -183,7 +202,7 @@ export const AnnotationPopupCSS = forwardRef<AnnotationPopupCSSHandle, Annotatio
                 setIsStylesExpanded(!isStylesExpanded);
                 if (wasExpanded) {
                   // Refocus textarea when closing
-                  originalSetTimeout(() => textareaRef.current?.focus(), 0);
+                  originalSetTimeout(() => focusBypassingTraps(textareaRef.current), 0);
                 }
               }}
               type="button"


### PR DESCRIPTION
## Summary

Fixes #32 — annotating an input inside a modal or drawer (vaul, Radix, shadcn) caused focus to stay on the host input instead of the annotation popup textarea.

- **Root cause**: Focus-trap libraries (Radix `FocusScope`) intercept `focusin`/`focusout` events and reclaim focus when it moves outside their scope. The popup's `.focus()` call would succeed momentarily but the trap immediately stole it back.
- **Fix**: A `focusBypassingTraps()` helper that temporarily blocks `focusin`/`focusout` propagation with a capture-phase `stopImmediatePropagation` handler for the duration of the `.focus()` call. Listeners are added and removed synchronously — zero side effects.
- Applied to all 3 focus sites in the annotation popup (mount, shake, styles accordion collapse).