### PR TITLE
fix: use :where() for toolbar positioning defaults

### DIFF
--- a/package/src/components/page-toolbar-css/styles.module.scss
+++ b/package/src/components/page-toolbar-css/styles.module.scss
@@ -231,8 +231,6 @@ $green: #34c759;
 
 .toolbar {
   position: fixed;
-  bottom: 1.25rem;
-  right: 1.25rem;
   width: 297px;
   z-index: 100000;
   font-family:
@@ -248,6 +246,13 @@ $green: #34c759;
     top 0s,
     right 0s,
     bottom 0s; // Instant positioning changes
+}
+
+// Positional defaults use :where() for zero specificity so consumer className can override.
+// See: https://github.com/benjitaylor/agentation/issues/146
+:where(.toolbar) {
+  bottom: 1.25rem;
+  right: 1.25rem;
 }
 
 .toolbarContainer {


### PR DESCRIPTION
## Summary

The `className` prop (added in #129) allows consumers to adjust toolbar positioning, but the package's `.toolbar` CSS has the same specificity as the consumer's class. Since package styles load after consumer styles in the DOM, consumers are forced to use `!important` to override `bottom`/`right`.

This wraps positional defaults (`bottom`, `right`) in `:where()` for zero specificity so consumer `className` classes naturally win — consistent with the existing `:where()` usage for form element resets.

## Changes

- **`styles.module.scss`**: Split `.toolbar` rule — non-positional styles stay at normal specificity, `bottom`/`right` defaults moved to `:where(.toolbar)` block

## Verification

- Package builds successfully
- Compiled CSS shows `:where(.styles-module__toolbar___wNsdK) { bottom: 1.25rem; right: 1.25rem; }`
- Default positioning still works when no `className` is provided
- Consumer `className` with `bottom: 140px` (no `!important`) now wins

Fixes #146