### PR TITLE
polish: ui

### DIFF
--- a/package/example/src/app/components/HeroDemo.tsx
+++ b/package/example/src/app/components/HeroDemo.tsx
@@ -578,7 +578,7 @@ Make this more prominent`;
 
   return (
     <div className="hero-demo-container">
-      <style>{`
+      <style suppressHydrationWarning>{`
         .hero-demo-container {
           position: relative;
           width: 100%;

--- a/package/src/components/annotation-popup-css/styles.module.scss
+++ b/package/src/components/annotation-popup-css/styles.module.scss
@@ -15,52 +15,49 @@
   }
 }
 
-$blue: #3c82f7;
-$green: #34c759;
-
 // =============================================================================
 // Animation Keyframes
 // =============================================================================
 
 @keyframes popupEnter {
-    from {
-        opacity: 0;
-        transform: translateX(-50%) scale(0.95) translateY(4px);
-    }
-    to {
-        opacity: 1;
-        transform: translateX(-50%) scale(1) translateY(0);
-    }
+  from {
+    opacity: 0;
+    transform: translateX(-50%) scale(0.95) translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) scale(1) translateY(0);
+  }
 }
 
 @keyframes popupExit {
-    from {
-        opacity: 1;
-        transform: translateX(-50%) scale(1) translateY(0);
-    }
-    to {
-        opacity: 0;
-        transform: translateX(-50%) scale(0.95) translateY(4px);
-    }
+  from {
+    opacity: 1;
+    transform: translateX(-50%) scale(1) translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(-50%) scale(0.95) translateY(4px);
+  }
 }
 
 @keyframes shake {
-    0%,
-    100% {
-        transform: translateX(-50%) scale(1) translateY(0) translateX(0);
-    }
-    20% {
-        transform: translateX(-50%) scale(1) translateY(0) translateX(-3px);
-    }
-    40% {
-        transform: translateX(-50%) scale(1) translateY(0) translateX(3px);
-    }
-    60% {
-        transform: translateX(-50%) scale(1) translateY(0) translateX(-2px);
-    }
-    80% {
-        transform: translateX(-50%) scale(1) translateY(0) translateX(2px);
-    }
+  0%,
+  100% {
+    transform: translateX(-50%) scale(1) translateY(0) translateX(0);
+  }
+  20% {
+    transform: translateX(-50%) scale(1) translateY(0) translateX(-3px);
+  }
+  40% {
+    transform: translateX(-50%) scale(1) translateY(0) translateX(3px);
+  }
+  60% {
+    transform: translateX(-50%) scale(1) translateY(0) translateX(-2px);
+  }
+  80% {
+    transform: translateX(-50%) scale(1) translateY(0) translateX(2px);
+  }
 }
 
 // =============================================================================
@@ -68,47 +65,47 @@ $green: #34c759;
 // =============================================================================
 
 .popup {
-    position: fixed;
-    transform: translateX(-50%);
-    width: 280px;
-    padding: 0.75rem 1rem 14px;
-    background: #1a1a1a;
-    border-radius: 16px;
-    box-shadow:
-        0 4px 24px rgba(0, 0, 0, 0.3),
-        0 0 0 1px rgba(255, 255, 255, 0.08);
-    cursor: default;
-    z-index: 100001;
-    font-family:
-        system-ui,
-        -apple-system,
-        BlinkMacSystemFont,
-        "Segoe UI",
-        Roboto,
-        sans-serif;
-    will-change: transform, opacity;
+  position: fixed;
+  transform: translateX(-50%);
+  width: 280px;
+  padding: 0.75rem 1rem 14px;
+  background: #1a1a1a;
+  border-radius: 16px;
+  box-shadow:
+    0 4px 24px rgba(0, 0, 0, 0.3),
+    0 0 0 1px rgba(255, 255, 255, 0.08);
+  cursor: default;
+  z-index: 100001;
+  font-family:
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    "Segoe UI",
+    Roboto,
+    sans-serif;
+  will-change: transform, opacity;
 
-    // Initial state (before animation)
-    opacity: 0;
+  // Initial state (before animation)
+  opacity: 0;
 
-    &.enter {
-        animation: popupEnter 0.2s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
-    }
+  &.enter {
+    animation: popupEnter 0.2s cubic-bezier(0.34, 1.56, 0.64, 1) forwards;
+  }
 
-    // After enter animation completes, set stable state
-    &.entered {
-        opacity: 1;
-        transform: translateX(-50%) scale(1) translateY(0);
-    }
+  // After enter animation completes, set stable state
+  &.entered {
+    opacity: 1;
+    transform: translateX(-50%) scale(1) translateY(0);
+  }
 
-    &.exit {
-        animation: popupExit 0.15s ease-in forwards;
-    }
+  &.exit {
+    animation: popupExit 0.15s ease-in forwards;
+  }
 
-    // Shake needs entered state to be stable first
-    &.entered.shake {
-        animation: shake 0.25s ease-out;
-    }
+  // Shake needs entered state to be stable first
+  &.entered.shake {
+    animation: shake 0.25s ease-out;
+  }
 }
 
 // =============================================================================
@@ -116,49 +113,49 @@ $green: #34c759;
 // =============================================================================
 
 .header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 0.5625rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.5625rem;
 }
 
 .element {
-    font-size: 0.75rem;
-    font-weight: 400;
-    color: rgba(255, 255, 255, 0.5);
-    max-width: 100%;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    flex: 1;
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.5);
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
 }
 
 .headerToggle {
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
-    background: none;
-    border: none;
-    padding: 0;
-    cursor: pointer;
-    flex: 1;
-    min-width: 0;
-    text-align: left;
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  flex: 1;
+  min-width: 0;
+  text-align: left;
 
-    .element {
-        flex: 1;
-    }
+  .element {
+    flex: 1;
+  }
 }
 
 // Chevron icon that rotates when computed styles are expanded
 .chevron {
-    color: rgba(255, 255, 255, 0.5);
-    transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1); // Matches FAQ accordion easing
-    flex-shrink: 0;
+  color: rgba(255, 255, 255, 0.5);
+  transition: transform 0.25s cubic-bezier(0.16, 1, 0.3, 1); // Matches FAQ accordion easing
+  flex-shrink: 0;
 
-    &.expanded {
-        transform: rotate(90deg);
-    }
+  &.expanded {
+    transform: rotate(90deg);
+  }
 }
 
 // =============================================================================
@@ -168,53 +165,53 @@ $green: #34c759;
 // Accordion animation using grid-template-rows technique for smooth height transitions
 // See: https://css-tricks.com/css-grid-can-do-auto-height-transitions/
 .stylesWrapper {
-    display: grid;
-    grid-template-rows: 0fr;
-    transition: grid-template-rows 0.3s cubic-bezier(0.16, 1, 0.3, 1); // Matches FAQ accordion easing
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.3s cubic-bezier(0.16, 1, 0.3, 1); // Matches FAQ accordion easing
 
-    &.expanded {
-        grid-template-rows: 1fr;
-    }
+  &.expanded {
+    grid-template-rows: 1fr;
+  }
 }
 
 // Inner container with overflow:hidden is required for the grid animation to work
 .stylesInner {
-    overflow: hidden;
+  overflow: hidden;
 }
 
 // Code-block styling for computed CSS properties display
 .stylesBlock {
-    background: rgba(255, 255, 255, 0.05);
-    border-radius: 0.375rem;
-    padding: 0.5rem 0.625rem;
-    margin-bottom: 0.5rem;
-    font-family:
-        ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
-    font-size: 0.6875rem;
-    line-height: 1.5;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 0.375rem;
+  padding: 0.5rem 0.625rem;
+  margin-bottom: 0.5rem;
+  font-family:
+    ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+  font-size: 0.6875rem;
+  line-height: 1.5;
 }
 
 .styleLine {
-    color: rgba(255, 255, 255, 0.85);
-    word-break: break-word;
+  color: rgba(255, 255, 255, 0.85);
+  word-break: break-word;
 }
 
 // Syntax highlighting colors (purple for properties, light for values)
 .styleProperty {
-    color: #c792ea;
+  color: #c792ea;
 }
 
 .styleValue {
-    color: rgba(255, 255, 255, 0.85);
+  color: rgba(255, 255, 255, 0.85);
 }
 
 .timestamp {
-    font-size: 0.625rem;
-    font-weight: 500;
-    color: rgba(255, 255, 255, 0.35);
-    font-variant-numeric: tabular-nums;
-    margin-left: 0.5rem;
-    flex-shrink: 0;
+  font-size: 0.625rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, 0.35);
+  font-variant-numeric: tabular-nums;
+  margin-left: 0.5rem;
+  flex-shrink: 0;
 }
 
 // =============================================================================
@@ -222,14 +219,14 @@ $green: #34c759;
 // =============================================================================
 
 .quote {
-    font-size: 12px;
-    font-style: italic;
-    color: rgba(255, 255, 255, 0.6);
-    margin-bottom: 0.5rem;
-    padding: 0.4rem 0.5rem;
-    background: rgba(255, 255, 255, 0.05);
-    border-radius: 0.25rem;
-    line-height: 1.45;
+  font-size: 12px;
+  font-style: italic;
+  color: rgba(255, 255, 255, 0.6);
+  margin-bottom: 0.5rem;
+  padding: 0.4rem 0.5rem;
+  background: rgba(255, 255, 255, 0.05);
+  border-radius: 0.25rem;
+  line-height: 1.45;
 }
 
 // =============================================================================
@@ -237,42 +234,42 @@ $green: #34c759;
 // =============================================================================
 
 .textarea {
-    width: 100%;
-    padding: 0.5rem 0.625rem;
-    font-size: 0.8125rem;
-    font-family: inherit;
-    background: rgba(255, 255, 255, 0.05);
-    color: #fff;
-    border: 1px solid rgba(255, 255, 255, 0.15);
-    border-radius: 8px;
-    resize: none;
-    outline: none;
-    transition: border-color 0.15s ease;
+  width: 100%;
+  padding: 0.5rem 0.625rem;
+  font-size: 0.8125rem;
+  font-family: inherit;
+  background: rgba(255, 255, 255, 0.05);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  border-radius: 8px;
+  resize: none;
+  outline: none;
+  transition: border-color 0.15s ease;
 
-    &:focus {
-        border-color: $blue;
-    }
+  &:focus {
+    border-color: var(--agentation-color-blue);
+  }
 
-    &.green:focus {
-        border-color: $green;
-    }
+  &.green:focus {
+    border-color: var(--agentation-color-green);
+  }
 
-    &::placeholder {
-        color: rgba(255, 255, 255, 0.35);
-    }
+  &::placeholder {
+    color: rgba(255, 255, 255, 0.35);
+  }
 
-    &::-webkit-scrollbar {
-        width: 6px;
-    }
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
 
-    &::-webkit-scrollbar-track {
-        background: transparent;
-    }
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
 
-    &::-webkit-scrollbar-thumb {
-        background: rgba(255, 255, 255, 0.2);
-        border-radius: 3px;
-    }
+  &::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.2);
+    border-radius: 3px;
+  }
 }
 
 // =============================================================================
@@ -280,77 +277,81 @@ $green: #34c759;
 // =============================================================================
 
 .actions {
-    display: flex;
-    justify-content: flex-end;
-    gap: 0.375rem;
-    margin-top: 0.5rem;
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.375rem;
+  margin-top: 0.5rem;
 }
 
 .cancel,
 .submit {
-    padding: 0.4rem 0.875rem;
-    font-size: 0.75rem;
-    font-weight: 500;
-    border-radius: 1rem;
-    border: none;
-    cursor: pointer;
-    transition:
-        background-color 0.15s ease,
-        color 0.15s ease,
-        opacity 0.15s ease;
+  padding: 0.4rem 0.875rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  border-radius: 1rem;
+  border: none;
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease,
+    opacity 0.15s ease;
 }
 
 .cancel {
-    background: transparent;
-    color: rgba(255, 255, 255, 0.5);
+  background: transparent;
+  color: rgba(255, 255, 255, 0.5);
 
-    &:hover {
-        background: rgba(255, 255, 255, 0.1);
-        color: rgba(255, 255, 255, 0.8);
-    }
+  &:hover {
+    background: rgba(255, 255, 255, 0.1);
+    color: rgba(255, 255, 255, 0.8);
+  }
 }
 
 .submit {
-    color: white;
+  color: white;
 
-    &:hover:not(:disabled) {
-        filter: brightness(0.9);
-    }
+  &:hover:not(:disabled) {
+    filter: brightness(0.9);
+  }
 
-    &:disabled {
-        cursor: not-allowed;
-    }
+  &:disabled {
+    cursor: not-allowed;
+  }
 }
 
 // Delete button wrapper
 .deleteWrapper {
-    margin-right: auto;
+  margin-right: auto;
 }
 
 .deleteButton {
-    cursor: pointer;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 28px;
-    border-radius: 50%;
-    border: none;
-    background: transparent;
-    color: rgba(255, 255, 255, 0.4);
-    transition:
-        background-color 0.15s ease,
-        color 0.15s ease,
-        transform 0.1s ease;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  border: none;
+  background: transparent;
+  color: rgba(255, 255, 255, 0.4);
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease,
+    transform 0.1s ease;
 
-    &:hover {
-        background: rgba(255, 59, 48, 0.25);
-        color: #ff3b30;
-    }
+  &:hover {
+    background-color: color-mix(
+      in srgb,
+      var(--agentation-color-red) 25%,
+      transparent
+    );
+    color: var(--agentation-color-red);
+  }
 
-    &:active {
-        transform: scale(0.92);
-    }
+  &:active {
+    transform: scale(0.92);
+  }
 }
 
 // =============================================================================
@@ -358,75 +359,79 @@ $green: #34c759;
 // =============================================================================
 
 .light {
-    &.popup {
-        background: #fff;
-        box-shadow:
-            0 4px 24px rgba(0, 0, 0, 0.12),
-            0 0 0 1px rgba(0, 0, 0, 0.06);
+  &.popup {
+    background: #fff;
+    box-shadow:
+      0 4px 24px rgba(0, 0, 0, 0.12),
+      0 0 0 1px rgba(0, 0, 0, 0.06);
+  }
+
+  .element {
+    color: rgba(0, 0, 0, 0.6);
+  }
+
+  .timestamp {
+    color: rgba(0, 0, 0, 0.4);
+  }
+
+  .chevron {
+    color: rgba(0, 0, 0, 0.4);
+  }
+
+  .stylesBlock {
+    background: rgba(0, 0, 0, 0.03);
+  }
+
+  .styleLine {
+    color: rgba(0, 0, 0, 0.75);
+  }
+
+  .styleProperty {
+    color: #7c3aed;
+  }
+
+  .styleValue {
+    color: rgba(0, 0, 0, 0.75);
+  }
+
+  .quote {
+    color: rgba(0, 0, 0, 0.55);
+    background: rgba(0, 0, 0, 0.04);
+  }
+
+  .textarea {
+    background: rgba(0, 0, 0, 0.03);
+    color: #1a1a1a;
+    border-color: rgba(0, 0, 0, 0.12);
+
+    &::placeholder {
+      color: rgba(0, 0, 0, 0.4);
     }
 
-    .element {
-        color: rgba(0, 0, 0, 0.6);
+    &::-webkit-scrollbar-thumb {
+      background: rgba(0, 0, 0, 0.15);
     }
+  }
 
-    .timestamp {
-        color: rgba(0, 0, 0, 0.4);
+  .cancel {
+    color: rgba(0, 0, 0, 0.5);
+
+    &:hover {
+      background: rgba(0, 0, 0, 0.06);
+      color: rgba(0, 0, 0, 0.75);
     }
+  }
 
-    .chevron {
-        color: rgba(0, 0, 0, 0.4);
+  .deleteButton {
+    color: rgba(0, 0, 0, 0.4);
+
+    &:hover {
+      background-color: color-mix(
+        in srgb,
+        var(--agentation-color-red) 25%,
+        transparent
+      );
+      color: var(--agentation-color-red);
     }
-
-    .stylesBlock {
-        background: rgba(0, 0, 0, 0.03);
-    }
-
-    .styleLine {
-        color: rgba(0, 0, 0, 0.75);
-    }
-
-    .styleProperty {
-        color: #7c3aed;
-    }
-
-    .styleValue {
-        color: rgba(0, 0, 0, 0.75);
-    }
-
-    .quote {
-        color: rgba(0, 0, 0, 0.55);
-        background: rgba(0, 0, 0, 0.04);
-    }
-
-    .textarea {
-        background: rgba(0, 0, 0, 0.03);
-        color: #1a1a1a;
-        border-color: rgba(0, 0, 0, 0.12);
-
-        &::placeholder {
-            color: rgba(0, 0, 0, 0.4);
-        }
-
-        &::-webkit-scrollbar-thumb {
-            background: rgba(0, 0, 0, 0.15);
-        }
-    }
-
-    .cancel {
-        color: rgba(0, 0, 0, 0.5);
-
-        &:hover {
-            background: rgba(0, 0, 0, 0.06);
-            color: rgba(0, 0, 0, 0.75);
-        }
-    }
-
-    .deleteButton {
-        color: rgba(0, 0, 0, 0.4);
-
-        &:hover {
-            background: rgba(255, 59, 48, 0.15);
-            color: #ff3b30;
-        }
-    }
+  }
 }

--- a/package/src/components/help-tooltip/index.tsx
+++ b/package/src/components/help-tooltip/index.tsx
@@ -1,0 +1,15 @@
+import { Tooltip } from "../tooltip";
+import { IconHelp } from "../icons";
+import styles from "./styles.module.scss";
+
+interface HelpTooltipProps {
+  content: string;
+}
+
+export const HelpTooltip = ({ content }: HelpTooltipProps) => {
+  return (
+    <Tooltip className={styles.tooltip} content={content}>
+      <IconHelp className={styles.tooltipIcon} />
+    </Tooltip>
+  );
+};

--- a/package/src/components/help-tooltip/styles.module.scss
+++ b/package/src/components/help-tooltip/styles.module.scss
@@ -1,0 +1,22 @@
+.tooltip {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  cursor: help;
+}
+
+.tooltipIcon {
+  transform: translateY(0.5px);
+  color: #fff;
+  opacity: 0.2;
+  transition: opacity 0.15s ease;
+  will-change: transform;
+
+  .tooltip:hover & {
+    opacity: 0.5;
+  }
+
+  [data-agentation-theme="light"] & {
+    color: #000;
+  }
+}

--- a/package/src/components/icons.tsx
+++ b/package/src/components/icons.tsx
@@ -103,23 +103,11 @@ export const IconListSparkle = ({
 );
 
 // Help/Question mark icon for tooltips
-export const IconHelp = ({ size = 20 }: { size?: number }) => (
-  <svg width={size} height={size} viewBox="0 0 20 20" fill="none">
-    <circle
-      cx="10"
-      cy="10.5"
-      r="5.25"
-      stroke="currentColor"
-      strokeWidth="1.25"
-    />
-    <path
-      d="M8.5 8.75C8.5 7.92 9.17 7.25 10 7.25C10.83 7.25 11.5 7.92 11.5 8.75C11.5 9.58 10.83 10.25 10 10.25V11"
-      stroke="currentColor"
-      strokeWidth="1.25"
-      strokeLinecap="round"
-      strokeLinejoin="round"
-    />
-    <circle cx="10" cy="13" r="0.75" fill="currentColor" />
+export const IconHelp = ({ size = 20, ...props }: { size?: number } & React.SVGProps<SVGSVGElement>) => (
+  <svg width={size} height={size} viewBox="0 0 20 20" fill="none" {...props}>
+    <circle cx="10" cy="10" r="6" stroke="currentColor" strokeWidth="1.25"/>
+    <path d="M8.24 8.19C8.38 7.78 8.66 7.44 9.03 7.23C9.4 7.01 9.84 6.93 10.26 7C10.68 7.07 11.06 7.29 11.34 7.62C11.61 7.95 11.76 8.36 11.76 8.79152C11.76 10 10 10.6 10 10.6V10.83" stroke="currentColor" strokeWidth="1.25" strokeLinecap="round" strokeLinejoin="round"/>
+    <circle cx="10" cy="13" r="0.625" fill="currentColor"/>
   </svg>
 );
 

--- a/package/src/components/icons.tsx
+++ b/package/src/components/icons.tsx
@@ -199,14 +199,14 @@ export const IconCopyAnimated = ({ size = 24, copied = false }: { size?: number;
     <g className={`${s.iconState} ${copied ? s.visibleScaled : s.hiddenScaled}`}>
       <path
         d="M12 20C7.58172 20 4 16.4182 4 12C4 7.58172 7.58172 4 12 4C16.4182 4 20 7.58172 20 12C20 16.4182 16.4182 20 12 20Z"
-        stroke="#22c55e"
+        stroke="var(--agentation-color-green)"
         strokeWidth="1.5"
         strokeLinecap="round"
         strokeLinejoin="round"
       />
       <path
         d="M15 10L11 14.25L9.25 12.25"
-        stroke="#22c55e"
+        stroke="var(--agentation-color-green)"
         strokeWidth="1.5"
         strokeLinecap="round"
         strokeLinejoin="round"
@@ -244,14 +244,14 @@ export const IconSendArrow = ({
       <g className={`${s.iconStateFast} ${showCheck ? s.visibleScaled : s.hiddenScaled}`}>
         <path
           d="M12 20C7.58172 20 4 16.4182 4 12C4 7.58172 7.58172 4 12 4C16.4182 4 20 7.58172 20 12C20 16.4182 16.4182 20 12 20Z"
-          stroke="#22c55e"
+          stroke="var(--agentation-color-green)"
           strokeWidth="1.5"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
         <path
           d="M15 10L11 14.25L9.25 12.25"
-          stroke="#22c55e"
+          stroke="var(--agentation-color-green)"
           strokeWidth="1.5"
           strokeLinecap="round"
           strokeLinejoin="round"
@@ -261,18 +261,18 @@ export const IconSendArrow = ({
       <g className={`${s.iconStateFast} ${showError ? s.visibleScaled : s.hiddenScaled}`}>
         <path
           d="M12 20C7.58172 20 4 16.4182 4 12C4 7.58172 7.58172 4 12 4C16.4182 4 20 7.58172 20 12C20 16.4182 16.4182 20 12 20Z"
-          stroke="#ef4444"
+          stroke="var(--agentation-color-red)"
           strokeWidth="1.5"
           strokeLinecap="round"
           strokeLinejoin="round"
         />
         <path
           d="M12 8V12"
-          stroke="#ef4444"
+          stroke="var(--agentation-color-red)"
           strokeWidth="1.5"
           strokeLinecap="round"
         />
-        <circle cx="12" cy="15" r="0.5" fill="#ef4444" stroke="#ef4444" strokeWidth="1" />
+        <circle cx="12" cy="15" r="0.5" fill="var(--agentation-color-red)" stroke="var(--agentation-color-red)" strokeWidth="1" />
       </g>
     </svg>
   );

--- a/package/src/components/page-toolbar-css/index.tsx
+++ b/package/src/components/page-toolbar-css/index.tsx
@@ -212,7 +212,9 @@ const COLOR_OPTIONS = [
 
 const injectAgentationColorTokens = () => {
   if (typeof document === "undefined") return;
+  if (document.getElementById("agentation-color-tokens")) return;
   const style = document.createElement("style");
+  style.id = "agentation-color-tokens";
   style.textContent = [
     ...COLOR_OPTIONS.map(c => `
       [data-agentation-accent="${c.id}"] {

--- a/package/src/components/page-toolbar-css/index.tsx
+++ b/package/src/components/page-toolbar-css/index.tsx
@@ -3619,7 +3619,7 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
                 (isHovered || isDeleting) && !editingAnnotation;
               const isMulti = annotation.isMultiSelect;
               const markerColor = isMulti
-                ? "#030404"
+                ? "var(--agentation-color-green)"
                 : "var(--agentation-color-accent)";
               const globalIndex = annotations.findIndex(
                 (a) => a.id === annotation.id,

--- a/package/src/components/page-toolbar-css/index.tsx
+++ b/package/src/components/page-toolbar-css/index.tsx
@@ -86,6 +86,8 @@ import {
 
 import type { Annotation } from "../../types";
 import styles from "./styles.module.scss";
+import { Tooltip } from "../tooltip";
+import { HelpTooltip } from "../help-tooltip";
 
 /**
  * Composes element identification with React component detection.
@@ -145,18 +147,18 @@ type MarkerClickBehavior = "edit" | "delete";
 type ToolbarSettings = {
   outputDetail: OutputDetailLevel;
   autoClearAfterCopy: boolean;
-  annotationColor: string;
+  annotationColorId: string;
   blockInteractions: boolean;
-  reactEnabled: boolean; // Simple toggle - mode derived from outputDetail
+  reactEnabled: boolean;
   markerClickBehavior: MarkerClickBehavior;
-  webhookUrl: string; // Overrides prop if set
+  webhookUrl: string;
   webhooksEnabled: boolean;
 };
 
 const DEFAULT_SETTINGS: ToolbarSettings = {
   outputDetail: "standard",
   autoClearAfterCopy: false,
-  annotationColor: "#3c82f7",
+  annotationColorId: "blue",
   blockInteractions: true,
   reactEnabled: true,
   markerClickBehavior: "edit",
@@ -199,14 +201,32 @@ const OUTPUT_DETAIL_OPTIONS: { value: OutputDetailLevel; label: string }[] = [
 ];
 
 const COLOR_OPTIONS = [
-  { value: "#AF52DE", label: "Purple" },
-  { value: "#3c82f7", label: "Blue" },
-  { value: "#5AC8FA", label: "Cyan" },
-  { value: "#34C759", label: "Green" },
-  { value: "#FFD60A", label: "Yellow" },
-  { value: "#FF9500", label: "Orange" },
-  { value: "#FF3B30", label: "Red" },
+  { id: "indigo",  label: "Indigo",  srgb: "#6155F5", p3: "color(display-p3 0.38 0.33 0.96)" },
+  { id: "blue",    label: "Blue",    srgb: "#0088FF", p3: "color(display-p3 0.00 0.53 1.00)" },
+  { id: "cyan",    label: "Cyan",    srgb: "#00C3D0", p3: "color(display-p3 0.00 0.76 0.82)" },
+  { id: "green",   label: "Green",   srgb: "#34C759", p3: "color(display-p3 0.20 0.78 0.35)" },
+  { id: "yellow",  label: "Yellow",  srgb: "#FFCC00", p3: "color(display-p3 1.00 0.80 0.00)" },
+  { id: "orange",  label: "Orange",  srgb: "#FF8D28", p3: "color(display-p3 1.00 0.55 0.16)" },
+  { id: "red",     label: "Red",     srgb: "#FF383C", p3: "color(display-p3 1.00 0.22 0.24)" },
 ];
+
+const injectAgentationColorTokens = () => {
+  if (typeof document === "undefined") return;
+  const style = document.createElement("style");
+  style.textContent = [
+    `:root {
+      ${COLOR_OPTIONS.map(c => `--agentation-color-${c.id}: ${c.srgb};`).join("\n")}
+    }`,
+    `@supports (color: color(display-p3 0 0 0)) {
+      :root {
+        ${COLOR_OPTIONS.map(c => `--agentation-color-${c.id}: ${c.p3};`).join("\n")}
+      }
+    }`,
+  ].join("");
+  document.head.appendChild(style);
+}
+
+injectAgentationColorTokens();
 
 // =============================================================================
 // Utils
@@ -581,7 +601,6 @@ export function PageFeedbackToolbarCSS({
   const [settingsPage, setSettingsPage] = useState<"main" | "automations">(
     "main",
   );
-  const [isTransitioning, setIsTransitioning] = useState(false);
   const [tooltipsHidden, setTooltipsHidden] = useState(false);
   const [tooltipSessionActive, setTooltipSessionActive] = useState(false);
   const tooltipSessionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
@@ -634,110 +653,30 @@ export function PageFeedbackToolbarCSS({
     };
   }, []);
 
-  // Tooltip component that renders via portal to escape overflow clipping
-  const Tooltip = ({
-    content,
-    children,
-  }: {
-    content: string;
-    children: React.ReactNode;
-  }) => {
-    const [isHovering, setIsHovering] = useState(false);
-    const [visible, setVisible] = useState(false);
-    const [shouldRender, setShouldRender] = useState(false);
-    const [position, setPosition] = useState({ top: 0, right: 0 });
-    const triggerRef = useRef<HTMLSpanElement>(null);
-    const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-    const exitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-    const updatePosition = () => {
-      if (triggerRef.current) {
-        const rect = triggerRef.current.getBoundingClientRect();
-        setPosition({
-          top: rect.top + rect.height / 2,
-          right: window.innerWidth - rect.left + 8,
-        });
-      }
+const [settings, setSettings] = useState<ToolbarSettings>(() => {
+  try {
+    const saved = JSON.parse(localStorage.getItem("feedback-toolbar-settings") ?? "");
+    return {
+      ...DEFAULT_SETTINGS,
+      ...saved,
+      annotationColorId: COLOR_OPTIONS.find(c => c.id === saved.annotationColorId)
+        ? saved.annotationColorId
+        : DEFAULT_SETTINGS.annotationColorId,
     };
-
-    const handleMouseEnter = () => {
-      setIsHovering(true);
-      setShouldRender(true);
-      if (exitTimeoutRef.current) {
-        clearTimeout(exitTimeoutRef.current);
-        exitTimeoutRef.current = null;
-      }
-      updatePosition();
-      timeoutRef.current = originalSetTimeout(() => {
-        setVisible(true);
-      }, 500); // 0.5s delay before showing
-    };
-
-    const handleMouseLeave = () => {
-      setIsHovering(false);
-      if (timeoutRef.current) {
-        clearTimeout(timeoutRef.current);
-        timeoutRef.current = null;
-      }
-      setVisible(false);
-      // Keep rendered during exit animation
-      exitTimeoutRef.current = originalSetTimeout(() => {
-        setShouldRender(false);
-      }, 150);
-    };
-
-    useEffect(() => {
-      return () => {
-        if (timeoutRef.current) clearTimeout(timeoutRef.current);
-        if (exitTimeoutRef.current) clearTimeout(exitTimeoutRef.current);
-      };
-    }, []);
-
-    return (
-      <>
-        <span
-          ref={triggerRef}
-          onMouseEnter={handleMouseEnter}
-          onMouseLeave={handleMouseLeave}
-        >
-          {children}
-        </span>
-        {shouldRender &&
-          createPortal(
-            <div
-              data-feedback-toolbar
-              style={{
-                position: "fixed",
-                top: position.top,
-                right: position.right,
-                transform: "translateY(-50%)",
-                padding: "6px 10px",
-                background: "#383838",
-                color: "rgba(255, 255, 255, 0.7)",
-                fontSize: "11px",
-                fontWeight: 400,
-                lineHeight: "14px",
-                borderRadius: "10px",
-                width: "180px",
-                textAlign: "left" as const,
-                zIndex: 100020,
-                pointerEvents: "none" as const,
-                boxShadow: "0px 1px 8px rgba(0, 0, 0, 0.28)",
-                opacity: visible && !isTransitioning ? 1 : 0,
-                transition: "opacity 0.15s ease",
-              }}
-            >
-              {content}
-            </div>,
-            document.body,
-          )}
-      </>
-    );
-  };
-
-  const [settings, setSettings] = useState<ToolbarSettings>(DEFAULT_SETTINGS);
+  } catch {
+    return DEFAULT_SETTINGS;
+  }
+});
   const [isDarkMode, setIsDarkMode] = useState(true);
   const [showEntranceAnimation, setShowEntranceAnimation] = useState(false);
+
+  const toggleTheme = () => {
+    portalWrapperRef.current?.classList.add(styles.disableTransitions);
+    setIsDarkMode((previous) => !previous);
+    requestAnimationFrame(() => {
+      portalWrapperRef.current?.classList.remove(styles.disableTransitions);
+    });
+  }
 
   // Check if running in development mode - React detection only works in development mode
   const isDevMode = process.env.NODE_ENV === "development";
@@ -814,12 +753,6 @@ export function PageFeedbackToolbarCSS({
     }
   }, [showSettings]);
 
-  useEffect(() => {
-    setIsTransitioning(true);
-    const timer = originalSetTimeout(() => setIsTransitioning(false), 350);
-    return () => clearTimeout(timer);
-  }, [settingsPage]);
-
   // Unified marker visibility - depends on BOTH toolbar active AND showMarkers toggle
   // This single effect handles all marker show/hide animations
   const shouldShowMarkers = isActive && showMarkers;
@@ -863,15 +796,6 @@ export function PageFeedbackToolbarCSS({
       hasPlayedEntranceAnimation = true;
       // Remove animation class after it completes (toolbar: 500ms, badge: 400ms delay + 300ms)
       originalSetTimeout(() => setShowEntranceAnimation(false), 750);
-    }
-
-    try {
-      const storedSettings = localStorage.getItem("feedback-toolbar-settings");
-      if (storedSettings) {
-        setSettings({ ...DEFAULT_SETTINGS, ...JSON.parse(storedSettings) });
-      }
-    } catch (e) {
-      // Ignore parsing errors
     }
 
     // Load saved theme preference, default to dark mode
@@ -1563,7 +1487,7 @@ export function PageFeedbackToolbarCSS({
         cursor: text !important;
       }
       [data-feedback-toolbar], [data-feedback-toolbar] * {
-        cursor: default !important;
+        cursor: auto !important;
       }
       [data-feedback-toolbar] textarea,
       [data-feedback-toolbar] input[type="text"],
@@ -3061,7 +2985,7 @@ export function PageFeedbackToolbarCSS({
   };
 
   return createPortal(
-    <div ref={portalWrapperRef} style={{ display: "contents" }}>
+    <div ref={portalWrapperRef} style={{ display: "contents", "--agentation-accent": settings.annotationColorId } as React.CSSProperties} data-agentation-theme={isDarkMode ? "dark" : "light"}>
       {/* Toolbar */}
       <div
         className={`${styles.toolbar}${userClassName ? ` ${userClassName}` : ""}`}
@@ -3079,7 +3003,7 @@ export function PageFeedbackToolbarCSS({
       >
         {/* Morphing container */}
         <div
-          className={`${styles.toolbarContainer} ${!isDarkMode ? styles.light : ""} ${isActive ? styles.expanded : styles.collapsed} ${showEntranceAnimation ? styles.entrance : ""} ${isToolbarHiding ? styles.hiding : ""} ${isDraggingToolbar ? styles.dragging : ""} ${!settings.webhooksEnabled && (isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "")) ? styles.serverConnected : ""}`}
+          className={`${styles.toolbarContainer} ${isActive ? styles.expanded : styles.collapsed} ${showEntranceAnimation ? styles.entrance : ""} ${isToolbarHiding ? styles.hiding : ""} ${isDraggingToolbar ? styles.dragging : ""} ${!settings.webhooksEnabled && (isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "")) ? styles.serverConnected : ""}`}
           onClick={
             !isActive
               ? (e) => {
@@ -3112,7 +3036,6 @@ export function PageFeedbackToolbarCSS({
             {hasAnnotations && (
               <span
                 className={`${styles.badge} ${isActive ? styles.fadeOut : ""} ${showEntranceAnimation ? styles.entrance : ""}`}
-                style={{ backgroundColor: settings.annotationColor }}
               >
                 {annotations.length}
               </span>
@@ -3137,7 +3060,7 @@ export function PageFeedbackToolbarCSS({
               }`}
             >
               <button
-                className={`${styles.controlButton} ${!isDarkMode ? styles.light : ""}`}
+                className={styles.controlButton}
                 onClick={(e) => {
                   e.stopPropagation();
                   hideTooltipsUntilMouseLeave();
@@ -3155,7 +3078,7 @@ export function PageFeedbackToolbarCSS({
 
             <div className={styles.buttonWrapper}>
               <button
-                className={`${styles.controlButton} ${!isDarkMode ? styles.light : ""}`}
+                className={styles.controlButton}
                 onClick={(e) => {
                   e.stopPropagation();
                   hideTooltipsUntilMouseLeave();
@@ -3173,7 +3096,7 @@ export function PageFeedbackToolbarCSS({
 
             <div className={styles.buttonWrapper}>
               <button
-                className={`${styles.controlButton} ${!isDarkMode ? styles.light : ""} ${copied ? styles.statusShowing : ""}`}
+                className={`${styles.controlButton} ${copied ? styles.statusShowing : ""}`}
                 onClick={(e) => {
                   e.stopPropagation();
                   hideTooltipsUntilMouseLeave();
@@ -3195,7 +3118,7 @@ export function PageFeedbackToolbarCSS({
               className={`${styles.buttonWrapper} ${styles.sendButtonWrapper} ${isActive && !settings.webhooksEnabled && (isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "")) ? styles.sendButtonVisible : ""}`}
             >
               <button
-                className={`${styles.controlButton} ${!isDarkMode ? styles.light : ""} ${sendState === "sent" || sendState === "failed" ? styles.statusShowing : ""}`}
+                className={`${styles.controlButton} ${sendState === "sent" || sendState === "failed" ? styles.statusShowing : ""}`}
                 onClick={(e) => {
                   e.stopPropagation();
                   hideTooltipsUntilMouseLeave();
@@ -3218,8 +3141,7 @@ export function PageFeedbackToolbarCSS({
                 <IconSendArrow size={24} state={sendState} />
                 {hasAnnotations && sendState === "idle" && (
                   <span
-                    className={`${styles.buttonBadge} ${!isDarkMode ? styles.light : ""}`}
-                    style={{ backgroundColor: settings.annotationColor }}
+                    className={styles.buttonBadge}
                   >
                     {annotations.length}
                   </span>
@@ -3233,7 +3155,7 @@ export function PageFeedbackToolbarCSS({
 
             <div className={styles.buttonWrapper}>
               <button
-                className={`${styles.controlButton} ${!isDarkMode ? styles.light : ""}`}
+                className={styles.controlButton}
                 onClick={(e) => {
                   e.stopPropagation();
                   hideTooltipsUntilMouseLeave();
@@ -3252,7 +3174,7 @@ export function PageFeedbackToolbarCSS({
 
             <div className={styles.buttonWrapper}>
               <button
-                className={`${styles.controlButton} ${!isDarkMode ? styles.light : ""}`}
+                className={styles.controlButton}
                 onClick={(e) => {
                   e.stopPropagation();
                   hideTooltipsUntilMouseLeave();
@@ -3263,7 +3185,7 @@ export function PageFeedbackToolbarCSS({
               </button>
               {endpoint && connectionStatus !== "disconnected" && (
                 <span
-                  className={`${styles.mcpIndicator} ${!isDarkMode ? styles.light : ""} ${styles[connectionStatus]} ${showSettings ? styles.hidden : ""}`}
+                  className={`${styles.mcpIndicator} ${styles[connectionStatus]} ${showSettings ? styles.hidden : ""}`}
                   title={
                     connectionStatus === "connected"
                       ? "MCP Connected"
@@ -3275,7 +3197,7 @@ export function PageFeedbackToolbarCSS({
             </div>
 
             <div
-              className={`${styles.divider} ${!isDarkMode ? styles.light : ""}`}
+              className={styles.divider}
             />
 
             <div
@@ -3288,7 +3210,7 @@ export function PageFeedbackToolbarCSS({
               }`}
             >
               <button
-                className={`${styles.controlButton} ${!isDarkMode ? styles.light : ""}`}
+                className={styles.controlButton}
                 onClick={(e) => {
                   e.stopPropagation();
                   hideTooltipsUntilMouseLeave();
@@ -3306,7 +3228,7 @@ export function PageFeedbackToolbarCSS({
 
           {/* Settings Panel */}
           <div
-            className={`${styles.settingsPanel} ${isDarkMode ? styles.dark : styles.light} ${showSettingsVisible ? styles.enter : styles.exit}`}
+            className={`${styles.settingsPanel} ${showSettingsVisible ? styles.enter : styles.exit}`}
             onClick={(e) => e.stopPropagation()}
             style={
               toolbarPosition && toolbarPosition.y < 230
@@ -3318,7 +3240,7 @@ export function PageFeedbackToolbarCSS({
             }
           >
             <div
-              className={`${styles.settingsPanelContainer} ${isTransitioning ? styles.transitioning : ""}`}
+              className={styles.settingsPanelContainer}
             >
               <div
                 className={`${styles.settingsPage} ${settingsPage === "automations" ? styles.slideLeft : ""}`}
@@ -3327,10 +3249,6 @@ export function PageFeedbackToolbarCSS({
                   <span className={styles.settingsBrand}>
                     <span
                       className={styles.settingsBrandSlash}
-                      style={{
-                        color: settings.annotationColor,
-                        transition: "color 0.2s ease",
-                      }}
                     >
                       /
                     </span>
@@ -3339,7 +3257,7 @@ export function PageFeedbackToolbarCSS({
                   <span className={styles.settingsVersion}>v{__VERSION__}</span>
                   <button
                     className={styles.themeToggle}
-                    onClick={() => setIsDarkMode(!isDarkMode)}
+                    onClick={toggleTheme}
                     title={
                       isDarkMode
                         ? "Switch to light mode"
@@ -3364,17 +3282,13 @@ export function PageFeedbackToolbarCSS({
                 <div className={styles.settingsSection}>
                   <div className={styles.settingsRow}>
                     <div
-                      className={`${styles.settingsLabel} ${!isDarkMode ? styles.light : ""}`}
+                      className={styles.settingsLabel}
                     >
                       Output Detail
-                      <Tooltip content="Controls how much detail is included in the copied output">
-                        <span className={styles.helpIcon}>
-                          <IconHelp size={20} />
-                        </span>
-                      </Tooltip>
+                      <HelpTooltip content="Controls how much detail is included in the copied output" />
                     </div>
                     <button
-                      className={`${styles.cycleButton} ${!isDarkMode ? styles.light : ""}`}
+                      className={styles.cycleButton}
                       onClick={() => {
                         const currentIndex = OUTPUT_DETAIL_OPTIONS.findIndex(
                           (opt) => opt.value === settings.outputDetail,
@@ -3401,7 +3315,7 @@ export function PageFeedbackToolbarCSS({
                         {OUTPUT_DETAIL_OPTIONS.map((option, i) => (
                           <span
                             key={option.value}
-                            className={`${styles.cycleDot} ${!isDarkMode ? styles.light : ""} ${settings.outputDetail === option.value ? styles.active : ""}`}
+                            className={`${styles.cycleDot} ${settings.outputDetail === option.value ? styles.active : ""}`}
                           />
                         ))}
                       </span>
@@ -3412,20 +3326,16 @@ export function PageFeedbackToolbarCSS({
                     className={`${styles.settingsRow} ${styles.settingsRowMarginTop} ${!isDevMode ? styles.settingsRowDisabled : ""}`}
                   >
                     <div
-                      className={`${styles.settingsLabel} ${!isDarkMode ? styles.light : ""}`}
+                      className={styles.settingsLabel}
                     >
                       React Components
-                      <Tooltip
+                      <HelpTooltip
                         content={
                           !isDevMode
                             ? "Disabled — production builds minify component names, making detection unreliable. Use in development mode."
                             : "Include React component names in annotations"
                         }
-                      >
-                        <span className={styles.helpIcon}>
-                          <IconHelp size={20} />
-                        </span>
-                      </Tooltip>
+                      />
                     </div>
                     <label
                       className={`${styles.toggleSwitch} ${!isDevMode ? styles.disabled : ""}`}
@@ -3447,14 +3357,10 @@ export function PageFeedbackToolbarCSS({
 
                   <div className={`${styles.settingsRow} ${styles.settingsRowMarginTop}`}>
                     <div
-                      className={`${styles.settingsLabel} ${!isDarkMode ? styles.light : ""}`}
+                      className={styles.settingsLabel}
                     >
                       Hide Until Restart
-                      <Tooltip content="Hides the toolbar until you open a new tab">
-                        <span className={styles.helpIcon}>
-                          <IconHelp size={20} />
-                        </span>
-                      </Tooltip>
+                      <HelpTooltip content="Hides the toolbar until you open a new tab" />
                     </div>
                     <label className={styles.toggleSwitch}>
                       <input
@@ -3473,32 +3379,24 @@ export function PageFeedbackToolbarCSS({
 
                 <div className={styles.settingsSection}>
                   <div
-                    className={`${styles.settingsLabel} ${styles.settingsLabelMarker} ${!isDarkMode ? styles.light : ""}`}
+                    className={`${styles.settingsLabel} ${styles.settingsLabelMarker}`}
                   >
-                    Marker Colour
+                    Marker Color
                   </div>
                   <div className={styles.colorOptions}>
-                    {COLOR_OPTIONS.map((color) => (
+                   {COLOR_OPTIONS.map((color) => (
                       <div
-                        key={color.value}
+                        key={color.id}
                         role="button"
-                        onClick={() =>
-                          setSettings((s) => ({
-                            ...s,
-                            annotationColor: color.value,
-                          }))
-                        }
+                        onClick={() => setSettings((s) => ({ ...s, annotationColorId: color.id }))}
                         style={{
-                          borderColor:
-                            settings.annotationColor === color.value
-                              ? color.value
-                              : "transparent",
-                        }}
-                        className={`${styles.colorOptionRing} ${settings.annotationColor === color.value ? styles.selected : ""}`}
+                          "--swatch": color.srgb,
+                          "--swatch-p3": color.p3,
+                        } as React.CSSProperties}
+                        className={`${styles.colorOptionRing} ${settings.annotationColorId === color.id ? styles.selected : ""}`}
                       >
                         <div
-                          className={`${styles.colorOption} ${settings.annotationColor === color.value ? styles.selected : ""}`}
-                          style={{ backgroundColor: color.value }}
+                          className={`${styles.colorOption} ${settings.annotationColorId === color.id ? styles.selected : ""}`}
                           title={color.label}
                         />
                       </div>
@@ -3528,16 +3426,10 @@ export function PageFeedbackToolbarCSS({
                       )}
                     </label>
                     <span
-                      className={`${styles.toggleLabel} ${!isDarkMode ? styles.light : ""}`}
+                      className={styles.toggleLabel}
                     >
                       Clear on copy/send
-                      <Tooltip content="Automatically clear annotations after copying">
-                        <span
-                          className={`${styles.helpIcon} ${styles.helpIconNudge2}`}
-                        >
-                          <IconHelp size={20} />
-                        </span>
-                      </Tooltip>
+                      <HelpTooltip content="Automatically clear annotations after copying" />
                     </span>
                   </label>
                   <label
@@ -3563,7 +3455,7 @@ export function PageFeedbackToolbarCSS({
                       )}
                     </label>
                     <span
-                      className={`${styles.toggleLabel} ${!isDarkMode ? styles.light : ""}`}
+                      className={styles.toggleLabel}
                     >
                       Block page interactions
                     </span>
@@ -3574,7 +3466,7 @@ export function PageFeedbackToolbarCSS({
                   className={`${styles.settingsSection} ${styles.settingsSectionExtraPadding}`}
                 >
                   <button
-                    className={`${styles.settingsNavLink} ${!isDarkMode ? styles.light : ""}`}
+                    className={styles.settingsNavLink}
                     onClick={() => setSettingsPage("automations")}
                   >
                     <span>Manage MCP & Webhooks</span>
@@ -3597,7 +3489,7 @@ export function PageFeedbackToolbarCSS({
                 className={`${styles.settingsPage} ${styles.automationsPage} ${settingsPage === "automations" ? styles.slideIn : ""}`}
               >
                 <button
-                  className={`${styles.settingsBackButton} ${!isDarkMode ? styles.light : ""}`}
+                  className={styles.settingsBackButton}
                   onClick={() => setSettingsPage("main")}
                 >
                   <IconChevronLeft size={16} />
@@ -3608,16 +3500,10 @@ export function PageFeedbackToolbarCSS({
                 <div className={styles.settingsSection}>
                   <div className={styles.settingsRow}>
                     <span
-                      className={`${styles.automationHeader} ${!isDarkMode ? styles.light : ""}`}
+                      className={styles.automationHeader}
                     >
                       MCP Connection
-                      <Tooltip content="Connect via Model Context Protocol to let AI agents like Claude Code receive annotations in real-time.">
-                        <span
-                          className={`${styles.helpIcon} ${styles.helpIconNudgeDown}`}
-                        >
-                          <IconHelp size={20} />
-                        </span>
-                      </Tooltip>
+                      <HelpTooltip content="Connect via Model Context Protocol to let AI agents like Claude Code receive annotations in real-time." />
                     </span>
                     {endpoint && (
                       <div
@@ -3633,7 +3519,7 @@ export function PageFeedbackToolbarCSS({
                     )}
                   </div>
                   <p
-                    className={`${styles.automationDescription} ${!isDarkMode ? styles.light : ""}`}
+                    className={styles.automationDescription}
                     style={{ paddingBottom: 6 }}
                   >
                     MCP connection allows agents to receive and act on
@@ -3642,7 +3528,7 @@ export function PageFeedbackToolbarCSS({
                       href="https://agentation.dev/mcp"
                       target="_blank"
                       rel="noopener noreferrer"
-                      className={`${styles.learnMoreLink} ${!isDarkMode ? styles.light : ""}`}
+                      className={styles.learnMoreLink}
                     >
                       Learn more
                     </a>
@@ -3655,20 +3541,14 @@ export function PageFeedbackToolbarCSS({
                 >
                   <div className={styles.settingsRow}>
                     <span
-                      className={`${styles.automationHeader} ${!isDarkMode ? styles.light : ""}`}
+                      className={styles.automationHeader}
                     >
                       Webhooks
-                      <Tooltip content="Send annotation data to any URL endpoint when annotations change. Useful for custom integrations.">
-                        <span
-                          className={`${styles.helpIcon} ${styles.helpIconNoNudge}`}
-                        >
-                          <IconHelp size={20} />
-                        </span>
-                      </Tooltip>
+                      <HelpTooltip content="Send annotation data to any URL endpoint when annotations change. Useful for custom integrations." />
                     </span>
                     <div className={styles.autoSendRow}>
                       <span
-                        className={`${styles.autoSendLabel} ${!isDarkMode ? styles.light : ""} ${settings.webhooksEnabled ? styles.active : ""}`}
+                        className={`${styles.autoSendLabel} ${settings.webhooksEnabled ? styles.active : ""}`}
                       >
                         Auto-Send
                       </span>
@@ -3691,20 +3571,15 @@ export function PageFeedbackToolbarCSS({
                     </div>
                   </div>
                   <p
-                    className={`${styles.automationDescription} ${!isDarkMode ? styles.light : ""}`}
+                    className={styles.automationDescription}
                   >
                     The webhook URL will receive live annotation changes and
                     annotation data.
                   </p>
                   <textarea
-                    className={`${styles.webhookUrlInput} ${!isDarkMode ? styles.light : ""}`}
+                    className={styles.webhookUrlInput}
                     placeholder="Webhook URL"
                     value={settings.webhookUrl}
-                    style={
-                      {
-                        "--marker-color": settings.annotationColor,
-                      } as React.CSSProperties
-                    }
                     onKeyDown={(e) => e.stopPropagation()}
                     onChange={(e) =>
                       setSettings((s) => ({
@@ -3733,8 +3608,8 @@ export function PageFeedbackToolbarCSS({
                 (isHovered || isDeleting) && !editingAnnotation;
               const isMulti = annotation.isMultiSelect;
               const markerColor = isMulti
-                ? "#34C759"
-                : settings.annotationColor;
+                ? "#030404"
+                : "var(--agentation-accent)";
               const globalIndex = annotations.findIndex(
                 (a) => a.id === annotation.id,
               );
@@ -3805,7 +3680,7 @@ export function PageFeedbackToolbarCSS({
                   )}
                   {isHovered && !editingAnnotation && (
                     <div
-                      className={`${styles.markerTooltip} ${!isDarkMode ? styles.light : ""} ${styles.enter}`}
+                      className={`${styles.markerTooltip} ${styles.enter}`}
                       style={getTooltipPosition(annotation)}
                     >
                       <span className={styles.markerQuote}>
@@ -3861,8 +3736,8 @@ export function PageFeedbackToolbarCSS({
                 (isHovered || isDeleting) && !editingAnnotation;
               const isMulti = annotation.isMultiSelect;
               const markerColor = isMulti
-                ? "#34C759"
-                : settings.annotationColor;
+                ? "var(--agentation-color-green)"
+                : "var(--agentation-accent)";
               const globalIndex = annotations.findIndex(
                 (a) => a.id === annotation.id,
               );
@@ -3933,7 +3808,7 @@ export function PageFeedbackToolbarCSS({
                   )}
                   {isHovered && !editingAnnotation && (
                     <div
-                      className={`${styles.markerTooltip} ${!isDarkMode ? styles.light : ""} ${styles.enter}`}
+                      className={`${styles.markerTooltip} ${styles.enter}`}
                       style={getTooltipPosition(annotation)}
                     >
                       <span className={styles.markerQuote}>
@@ -3996,8 +3871,8 @@ export function PageFeedbackToolbarCSS({
                   top: hoverInfo.rect.top,
                   width: hoverInfo.rect.width,
                   height: hoverInfo.rect.height,
-                  borderColor: `${settings.annotationColor}80`,
-                  backgroundColor: `${settings.annotationColor}0A`,
+                  borderColor: "color-mix(in srgb, var(--agentation-accent) 50%, transparent)",
+                  backgroundColor: "color-mix(in srgb, var(--agentation-accent) 4%, transparent)",
                 }}
               />
             )}
@@ -4026,8 +3901,8 @@ export function PageFeedbackToolbarCSS({
                     ...(isMulti
                       ? {}
                       : {
-                          borderColor: `${settings.annotationColor}99`,
-                          backgroundColor: `${settings.annotationColor}0D`,
+                          borderColor: "color-mix(in srgb, var(--agentation-accent) 60%, transparent)",
+                          backgroundColor: "color-mix(in srgb, var(--agentation-accent) 5%, transparent)",
                         }),
                   }}
                 />
@@ -4111,8 +3986,8 @@ export function PageFeedbackToolbarCSS({
                     ...(isMulti
                       ? {}
                       : {
-                          borderColor: `${settings.annotationColor}99`,
-                          backgroundColor: `${settings.annotationColor}0D`,
+                          borderColor: "color-mix(in srgb, var(--agentation-accent) 60%, transparent)",
+                          backgroundColor: "color-mix(in srgb, var(--agentation-accent) 5%, transparent)",
                         }),
                   }}
                 />
@@ -4183,8 +4058,8 @@ export function PageFeedbackToolbarCSS({
                               top: rect.top,
                               width: rect.width,
                               height: rect.height,
-                              borderColor: `${settings.annotationColor}99`,
-                              backgroundColor: `${settings.annotationColor}0D`,
+                              borderColor: "color-mix(in srgb, var(--agentation-accent) 60%, transparent)",
+                              backgroundColor: "color-mix(in srgb, var(--agentation-accent) 5%, transparent)",
                             }}
                           />
                         );
@@ -4201,8 +4076,8 @@ export function PageFeedbackToolbarCSS({
                             ...(pendingAnnotation.isMultiSelect
                               ? {}
                               : {
-                                  borderColor: `${settings.annotationColor}99`,
-                                  backgroundColor: `${settings.annotationColor}0D`,
+                                  borderColor: "color-mix(in srgb, var(--agentation-accent) 60%, transparent)",
+                                  backgroundColor: "color-mix(in srgb, var(--agentation-accent) 5%, transparent)",
                                 }),
                           }}
                         />
@@ -4223,8 +4098,8 @@ export function PageFeedbackToolbarCSS({
                         left: `${markerX}%`,
                         top: markerY,
                         backgroundColor: pendingAnnotation.isMultiSelect
-                          ? "#34C759"
-                          : settings.annotationColor,
+                          ? "var(--agentation-color-green)"
+                          : "var(--agentation-accent)",
                       }}
                     >
                       <IconPlus size={12} />
@@ -4248,8 +4123,8 @@ export function PageFeedbackToolbarCSS({
                       lightMode={!isDarkMode}
                       accentColor={
                         pendingAnnotation.isMultiSelect
-                          ? "#34C759"
-                          : settings.annotationColor
+                          ? "var(--agentation-color-green)"
+                          : "var(--agentation-accent)"
                       }
                       style={{
                         // Popup is 280px wide, centered with translateX(-50%), so 140px each side
@@ -4351,8 +4226,8 @@ export function PageFeedbackToolbarCSS({
                           ...(editingAnnotation.isMultiSelect
                             ? {}
                             : {
-                                borderColor: `${settings.annotationColor}99`,
-                                backgroundColor: `${settings.annotationColor}0D`,
+                                borderColor: "color-mix(in srgb, var(--agentation-accent) 60%, transparent)",
+                                backgroundColor: "color-mix(in srgb, var(--agentation-accent) 5%, transparent)",
                               }),
                         }}
                       />
@@ -4376,8 +4251,8 @@ export function PageFeedbackToolbarCSS({
                 lightMode={!isDarkMode}
                 accentColor={
                   editingAnnotation.isMultiSelect
-                    ? "#34C759"
-                    : settings.annotationColor
+                    ? "var(--agentation-color-green)"
+                    : "var(--agentation-accent)"
                 }
                 style={(() => {
                   const markerY = editingAnnotation.isFixed

--- a/package/src/components/page-toolbar-css/index.tsx
+++ b/package/src/components/page-toolbar-css/index.tsx
@@ -214,6 +214,17 @@ const injectAgentationColorTokens = () => {
   if (typeof document === "undefined") return;
   const style = document.createElement("style");
   style.textContent = [
+    ...COLOR_OPTIONS.map(c => `
+      [data-agentation-accent="${c.id}"] {
+        --agentation-color-accent: ${c.srgb};
+      }
+
+      @supports (color: color(display-p3 0 0 0)) {
+        [data-agentation-accent="${c.id}"] {
+          --agentation-color-accent: ${c.p3};
+        }
+      }
+    `),
     `:root {
       ${COLOR_OPTIONS.map(c => `--agentation-color-${c.id}: ${c.srgb};`).join("\n")}
     }`,
@@ -2985,7 +2996,7 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
   };
 
   return createPortal(
-    <div ref={portalWrapperRef} style={{ display: "contents", "--agentation-accent": settings.annotationColorId } as React.CSSProperties} data-agentation-theme={isDarkMode ? "dark" : "light"}>
+    <div ref={portalWrapperRef} style={{ display: "contents" }} data-agentation-theme={isDarkMode ? "dark" : "light"} data-agentation-accent={settings.annotationColorId}>
       {/* Toolbar */}
       <div
         className={`${styles.toolbar}${userClassName ? ` ${userClassName}` : ""}`}
@@ -3609,7 +3620,7 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
               const isMulti = annotation.isMultiSelect;
               const markerColor = isMulti
                 ? "#030404"
-                : "var(--agentation-accent)";
+                : "var(--agentation-color-accent)";
               const globalIndex = annotations.findIndex(
                 (a) => a.id === annotation.id,
               );
@@ -3737,7 +3748,7 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
               const isMulti = annotation.isMultiSelect;
               const markerColor = isMulti
                 ? "var(--agentation-color-green)"
-                : "var(--agentation-accent)";
+                : "var(--agentation-color-accent)";
               const globalIndex = annotations.findIndex(
                 (a) => a.id === annotation.id,
               );
@@ -3871,8 +3882,8 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
                   top: hoverInfo.rect.top,
                   width: hoverInfo.rect.width,
                   height: hoverInfo.rect.height,
-                  borderColor: "color-mix(in srgb, var(--agentation-accent) 50%, transparent)",
-                  backgroundColor: "color-mix(in srgb, var(--agentation-accent) 4%, transparent)",
+                  borderColor: "color-mix(in srgb, var(--agentation-color-accent) 50%, transparent)",
+                  backgroundColor: "color-mix(in srgb, var(--agentation-color-accent) 4%, transparent)",
                 }}
               />
             )}
@@ -3901,8 +3912,8 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
                     ...(isMulti
                       ? {}
                       : {
-                          borderColor: "color-mix(in srgb, var(--agentation-accent) 60%, transparent)",
-                          backgroundColor: "color-mix(in srgb, var(--agentation-accent) 5%, transparent)",
+                          borderColor: "color-mix(in srgb, var(--agentation-color-accent) 60%, transparent)",
+                          backgroundColor: "color-mix(in srgb, var(--agentation-color-accent) 5%, transparent)",
                         }),
                   }}
                 />
@@ -3986,8 +3997,8 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
                     ...(isMulti
                       ? {}
                       : {
-                          borderColor: "color-mix(in srgb, var(--agentation-accent) 60%, transparent)",
-                          backgroundColor: "color-mix(in srgb, var(--agentation-accent) 5%, transparent)",
+                          borderColor: "color-mix(in srgb, var(--agentation-color-accent) 60%, transparent)",
+                          backgroundColor: "color-mix(in srgb, var(--agentation-color-accent) 5%, transparent)",
                         }),
                   }}
                 />
@@ -4058,8 +4069,8 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
                               top: rect.top,
                               width: rect.width,
                               height: rect.height,
-                              borderColor: "color-mix(in srgb, var(--agentation-accent) 60%, transparent)",
-                              backgroundColor: "color-mix(in srgb, var(--agentation-accent) 5%, transparent)",
+                              borderColor: "color-mix(in srgb, var(--agentation-color-accent) 60%, transparent)",
+                              backgroundColor: "color-mix(in srgb, var(--agentation-color-accent) 5%, transparent)",
                             }}
                           />
                         );
@@ -4076,8 +4087,8 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
                             ...(pendingAnnotation.isMultiSelect
                               ? {}
                               : {
-                                  borderColor: "color-mix(in srgb, var(--agentation-accent) 60%, transparent)",
-                                  backgroundColor: "color-mix(in srgb, var(--agentation-accent) 5%, transparent)",
+                                  borderColor: "color-mix(in srgb, var(--agentation-color-accent) 60%, transparent)",
+                                  backgroundColor: "color-mix(in srgb, var(--agentation-color-accent) 5%, transparent)",
                                 }),
                           }}
                         />
@@ -4099,7 +4110,7 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
                         top: markerY,
                         backgroundColor: pendingAnnotation.isMultiSelect
                           ? "var(--agentation-color-green)"
-                          : "var(--agentation-accent)",
+                          : "var(--agentation-color-accent)",
                       }}
                     >
                       <IconPlus size={12} />
@@ -4124,7 +4135,7 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
                       accentColor={
                         pendingAnnotation.isMultiSelect
                           ? "var(--agentation-color-green)"
-                          : "var(--agentation-accent)"
+                          : "var(--agentation-color-accent)"
                       }
                       style={{
                         // Popup is 280px wide, centered with translateX(-50%), so 140px each side
@@ -4226,8 +4237,8 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
                           ...(editingAnnotation.isMultiSelect
                             ? {}
                             : {
-                                borderColor: "color-mix(in srgb, var(--agentation-accent) 60%, transparent)",
-                                backgroundColor: "color-mix(in srgb, var(--agentation-accent) 5%, transparent)",
+                                borderColor: "color-mix(in srgb, var(--agentation-color-accent) 60%, transparent)",
+                                backgroundColor: "color-mix(in srgb, var(--agentation-color-accent) 5%, transparent)",
                               }),
                         }}
                       />
@@ -4252,7 +4263,7 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
                 accentColor={
                   editingAnnotation.isMultiSelect
                     ? "var(--agentation-color-green)"
-                    : "var(--agentation-accent)"
+                    : "var(--agentation-color-accent)"
                 }
                 style={(() => {
                   const markerY = editingAnnotation.isFixed

--- a/package/src/components/page-toolbar-css/styles.module.scss
+++ b/package/src/components/page-toolbar-css/styles.module.scss
@@ -1275,7 +1275,7 @@
 .automationsPage {
   position: absolute;
   top: 0;
-  left: 20px;
+  left: 24px;
   width: 100%;
   height: 100%;
   padding: 3px 1rem 0;

--- a/package/src/components/page-toolbar-css/styles.module.scss
+++ b/package/src/components/page-toolbar-css/styles.module.scss
@@ -39,10 +39,6 @@
   outline: unset;
 }
 
-$blue: #3c82f7;
-$red: #ff3b30;
-$green: #34c759;
-
 // =============================================================================
 // Animation Keyframes
 // =============================================================================
@@ -225,6 +221,11 @@ $green: #34c759;
   }
 }
 
+// Disable transitions on theme toggle
+.disableTransitions :is(*, *::before, *::after) {
+  transition: none !important;
+}
+
 // =============================================================================
 // Toolbar
 // =============================================================================
@@ -371,7 +372,7 @@ $green: #34c759;
   height: 18px;
   padding: 0 5px;
   border-radius: 9px;
-  background: $blue;
+  background-color: var(--agentation-accent);
   color: white;
   font-size: 0.625rem;
   font-weight: 600;
@@ -418,7 +419,9 @@ $green: #34c759;
 
   &:hover:not(:disabled):not([data-active="true"]):not(
       [data-failed="true"]
-    ):not([data-auto-sync="true"]):not([data-error="true"]):not([data-no-hover="true"]) {
+    ):not([data-auto-sync="true"]):not([data-error="true"]):not(
+      [data-no-hover="true"]
+    ) {
     background: rgba(255, 255, 255, 0.12);
     color: #fff;
   }
@@ -433,20 +436,32 @@ $green: #34c759;
   }
 
   &[data-active="true"] {
-    color: $blue;
-    background: rgba($blue, 0.25);
+    color: var(--agentation-color-blue);
+    background-color: color-mix(
+      in srgb,
+      var(--agentation-color-blue) 25%,
+      transparent
+    );
   }
 
   &[data-error="true"] {
-    color: $red;
-    background: rgba($red, 0.25);
+    color: var(--agentation-color-red);
+    background-color: color-mix(
+      in srgb,
+      var(--agentation-color-red) 25%,
+      transparent
+    );
   }
 
   &[data-danger]:hover:not(:disabled):not([data-active="true"]):not(
       [data-failed="true"]
     ) {
-    background: rgba($red, 0.25);
-    color: $red;
+    background-color: color-mix(
+      in srgb,
+      var(--agentation-color-red) 25%,
+      transparent
+    );
+    color: var(--agentation-color-red);
   }
 
   &[data-no-hover="true"],
@@ -458,15 +473,19 @@ $green: #34c759;
 
   // Auto-sync mode (Claude Code) - green, non-interactive
   &[data-auto-sync="true"] {
-    color: $green;
+    color: var(--agentation-color-green);
     background: transparent;
     cursor: default;
   }
 
   // Failed state (no listeners) - red like danger hover
   &[data-failed="true"] {
-    color: $red;
-    background: rgba($red, 0.25);
+    color: var(--agentation-color-red);
+    background-color: color-mix(
+      in srgb,
+      var(--agentation-color-red) 25%,
+      transparent
+    );
   }
 }
 
@@ -478,7 +497,7 @@ $green: #34c759;
   height: 16px;
   padding: 0 4px;
   border-radius: 8px;
-  background: $blue;
+  background-color: var(--agentation-accent);
   color: white;
   font-size: 0.625rem;
   font-weight: 600;
@@ -490,7 +509,7 @@ $green: #34c759;
     0 1px 3px rgba(0, 0, 0, 0.2);
   pointer-events: none;
 
-  &.light {
+  [data-agentation-theme="light"] & {
     box-shadow:
       0 0 0 2px #fff,
       0 1px 3px rgba(0, 0, 0, 0.2);
@@ -501,20 +520,24 @@ $green: #34c759;
 @keyframes mcpIndicatorPulseConnected {
   0%,
   100% {
-    box-shadow: 0 0 0 0 rgba($green, 0.5);
+    box-shadow: 0 0 0 0
+      color-mix(in srgb, var(--agentation-color-green) 50%, transparent);
   }
   50% {
-    box-shadow: 0 0 0 5px rgba($green, 0);
+    box-shadow: 0 0 0 5px
+      color-mix(in srgb, var(--agentation-color-green) 0%, transparent);
   }
 }
 
 @keyframes mcpIndicatorPulseConnecting {
   0%,
   100% {
-    box-shadow: 0 0 0 0 rgba(#f5a623, 0.5);
+    box-shadow: 0 0 0 0
+      color-mix(in srgb, var(--agentation-color-yellow) 50%, transparent);
   }
   50% {
-    box-shadow: 0 0 0 5px rgba(#f5a623, 0);
+    box-shadow: 0 0 0 5px
+      color-mix(in srgb, var(--agentation-color-yellow) 0%, transparent);
   }
 }
 
@@ -527,19 +550,19 @@ $green: #34c759;
   border-radius: 50%;
   pointer-events: none;
   transition:
-    background 0.3s ease,
+    background-color 0.3s ease,
     opacity 0.15s ease,
     transform 0.15s ease;
   opacity: 1;
   transform: scale(1);
 
   &.connected {
-    background: $green;
+    background-color: var(--agentation-color-green);
     animation: mcpIndicatorPulseConnected 2.5s ease-in-out infinite;
   }
 
   &.connecting {
-    background: #f5a623;
+    background-color: var(--agentation-color-yellow);
     animation: mcpIndicatorPulseConnecting 1.5s ease-in-out infinite;
   }
 
@@ -578,7 +601,7 @@ $green: #34c759;
   opacity: 0;
   transition:
     opacity 0.3s ease,
-    background 0.3s ease;
+    background-color 0.3s ease;
   cursor: default;
 }
 
@@ -587,17 +610,17 @@ $green: #34c759;
 }
 
 .connectionIndicatorConnected {
-  background: $green;
+  background-color: var(--agentation-color-green);
   animation: connectionPulse 2.5s ease-in-out infinite;
 }
 
 .connectionIndicatorDisconnected {
-  background: $red;
+  background-color: var(--agentation-color-red);
   animation: none;
 }
 
 .connectionIndicatorConnecting {
-  background: #f59e0b;
+  background-color: var(--agentation-color-yellow);
   animation: connectionPulse 1s ease-in-out infinite;
 }
 
@@ -817,10 +840,15 @@ $green: #34c759;
 
 .hoverHighlight {
   position: fixed;
-  border: 2px solid rgba($blue, 0.5);
+  border: 2px solid
+    color-mix(in srgb, var(--agentation-accent) 50%, transparent);
   border-radius: 4px;
+  background-color: color-mix(
+    in srgb,
+    var(--agentation-accent) 4%,
+    transparent
+  );
   pointer-events: none !important;
-  background: rgba($blue, 0.04);
   box-sizing: border-box;
   will-change: opacity;
   contain: layout style;
@@ -832,10 +860,15 @@ $green: #34c759;
 
 .multiSelectOutline {
   position: fixed;
-  border: 2px dashed rgba($green, 0.6);
+  border: 2px dashed
+    color-mix(in srgb, var(--agentation-accent) 60%, transparent);
   border-radius: 4px;
   pointer-events: none !important;
-  background: rgba($green, 0.05);
+  background-color: color-mix(
+    in srgb,
+    var(--agentation-accent) 5%,
+    transparent
+  );
   box-sizing: border-box;
   will-change: opacity;
 
@@ -850,10 +883,15 @@ $green: #34c759;
 
 .singleSelectOutline {
   position: fixed;
-  border: 2px solid rgba($blue, 0.6);
+  border: 2px solid
+    color-mix(in srgb, var(--agentation-color-blue) 60%, transparent);
   border-radius: 4px;
   pointer-events: none !important;
-  background: rgba($blue, 0.05);
+  background-color: color-mix(
+    in srgb,
+    var(--agentation-color-blue) 5%,
+    transparent
+  );
   box-sizing: border-box;
   will-change: opacity;
 
@@ -938,7 +976,7 @@ $green: #34c759;
   position: absolute;
   width: 22px;
   height: 22px;
-  background: $blue;
+  background: var(--agentation-color-blue);
   color: white;
   border-radius: 50%;
   display: flex;
@@ -989,7 +1027,7 @@ $green: #34c759;
 
   &.pending {
     position: fixed;
-    background: $blue;
+    background-color: var(--agentation-color-blue);
   }
 
   &.fixed {
@@ -997,19 +1035,19 @@ $green: #34c759;
   }
 
   &.multiSelect {
-    background: $green;
+    background-color: var(--agentation-color-green);
     width: 26px;
     height: 26px;
     border-radius: 6px;
     font-size: 0.75rem;
 
     &.pending {
-      background: $green;
+      background-color: var(--agentation-color-green);
     }
   }
 
   &.hovered {
-    background: $red;
+    background-color: var(--agentation-color-red);
   }
 }
 
@@ -1114,7 +1152,7 @@ $green: #34c759;
     0 1px 8px rgba(0, 0, 0, 0.25),
     0 0 0 1px rgba(0, 0, 0, 0.04);
   transition:
-    background 0.25s ease,
+    background-color 0.25s ease,
     box-shadow 0.25s ease;
 
   // Gradient overlays for smooth edge fade during transitions
@@ -1153,10 +1191,9 @@ $green: #34c759;
   .customCheckbox,
   .sliderLabel,
   .slider,
-  .helpIcon,
   .themeToggle {
     transition:
-      background 0.25s ease,
+      background-color 0.25s ease,
       color 0.25s ease,
       border-color 0.25s ease;
   }
@@ -1182,7 +1219,7 @@ $green: #34c759;
       filter 0.1s ease;
   }
 
-  &.dark {
+  [data-agentation-theme="dark"] & {
     background: #1a1a1a;
     box-shadow:
       0 4px 20px rgba(0, 0, 0, 0.3),
@@ -1217,31 +1254,28 @@ $green: #34c759;
   position: relative;
   display: flex;
   padding: 0 1rem;
-
-  &.transitioning {
-    overflow-x: clip;
-    overflow-y: visible;
-  }
 }
 
 .settingsPage {
   min-width: 100%;
   flex-shrink: 0;
   transition:
-    transform 0.35s cubic-bezier(0.32, 0.72, 0, 1),
-    opacity 0.2s ease-out;
+    transform 0.2s ease,
+    opacity 0.2s ease;
+  transition-delay: 0s;
   opacity: 1;
 }
 
 .settingsPage.slideLeft {
-  transform: translateX(-100%);
+  transform: translateX(-24px);
   opacity: 0;
+  pointer-events: none;
 }
 
 .automationsPage {
   position: absolute;
   top: 0;
-  left: 100%;
+  left: 20px;
   width: 100%;
   height: 100%;
   padding: 3px 1rem 0;
@@ -1249,14 +1283,16 @@ $green: #34c759;
   display: flex;
   flex-direction: column;
   transition:
-    transform 0.35s cubic-bezier(0.32, 0.72, 0, 1),
-    opacity 0.25s ease-out 0.1s;
+    transform 0.2s ease,
+    opacity 0.2s ease;
   opacity: 0;
+  pointer-events: none;
 }
 
 .automationsPage.slideIn {
-  transform: translateX(-100%);
+  transform: translateX(-24px);
   opacity: 1;
+  pointer-events: auto;
 }
 
 .settingsNavLink {
@@ -1278,7 +1314,7 @@ $green: #34c759;
     color: rgba(255, 255, 255, 0.9);
   }
 
-  &.light {
+  [data-agentation-theme="light"] & {
     color: rgba(0, 0, 0, 0.5);
 
     &:hover {
@@ -1295,11 +1331,11 @@ $green: #34c759;
     color: #fff;
   }
 
-  &.light svg {
+  [data-agentation-theme="light"] & svg {
     color: rgba(0, 0, 0, 0.25);
   }
 
-  &.light:hover svg {
+  [data-agentation-theme="light"] &:hover svg {
     color: rgba(0, 0, 0, 0.8);
   }
 }
@@ -1317,12 +1353,12 @@ $green: #34c759;
   flex-shrink: 0;
 
   &.connected {
-    background: $green;
+    background-color: var(--agentation-color-green);
     animation: mcpPulse 2.5s ease-in-out infinite;
   }
 
   &.connecting {
-    background: #f5a623;
+    background-color: var(--agentation-color-yellow);
     animation: mcpPulse 1.5s ease-in-out infinite;
   }
 }
@@ -1361,7 +1397,7 @@ $green: #34c759;
     }
   }
 
-  &.light {
+  [data-agentation-theme="light"] & {
     color: rgba(0, 0, 0, 0.85);
     border-bottom-color: rgba(0, 0, 0, 0.08);
 
@@ -1379,11 +1415,7 @@ $green: #34c759;
   font-weight: 400;
   color: #fff;
 
-  .helpIcon svg {
-    transform: none;
-  }
-
-  &.light {
+  [data-agentation-theme="light"] & {
     color: rgba(0, 0, 0, 0.85);
   }
 }
@@ -1395,7 +1427,7 @@ $green: #34c759;
   margin-top: 2px;
   line-height: 14px;
 
-  &.light {
+  [data-agentation-theme="light"] & {
     color: rgba(0, 0, 0, 0.5);
   }
 }
@@ -1411,7 +1443,7 @@ $green: #34c759;
     color: #fff;
   }
 
-  &.light {
+  [data-agentation-theme="light"] & {
     color: rgba(0, 0, 0, 0.6);
     text-decoration-color: rgba(0, 0, 0, 0.2);
 
@@ -1435,13 +1467,14 @@ $green: #34c759;
 
   &.active {
     color: #66b8ff;
+    color: color(display-p3 0.4 0.72 1);
   }
 
-  &.light {
+  [data-agentation-theme="light"] & {
     color: rgba(0, 0, 0, 0.4);
 
     &.active {
-      color: $blue;
+      color: var(--agentation-color-blue);
     }
   }
 }
@@ -1467,7 +1500,7 @@ $green: #34c759;
   user-select: text;
   transition:
     border-color 0.15s ease,
-    background 0.15s ease,
+    background-color 0.15s ease,
     box-shadow 0.15s ease;
 
   &::placeholder {
@@ -1479,7 +1512,7 @@ $green: #34c759;
     background: rgba(255, 255, 255, 0.08);
   }
 
-  &.light {
+  [data-agentation-theme="light"] & {
     border-color: rgba(0, 0, 0, 0.1);
     background: rgba(0, 0, 0, 0.03);
     color: rgba(0, 0, 0, 0.85);
@@ -1513,7 +1546,8 @@ $green: #34c759;
 }
 
 .settingsBrandSlash {
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--agentation-accent);
+  transition: color 0.2s ease;
 }
 
 .settingsVersion {
@@ -1599,7 +1633,7 @@ $green: #34c759;
   cursor: pointer;
   letter-spacing: -0.0094em;
 
-  &.light {
+  [data-agentation-theme="light"] & {
     color: rgba(0, 0, 0, 0.85);
   }
 
@@ -1613,7 +1647,7 @@ $green: #34c759;
   .settingsLabel {
     color: rgba(255, 255, 255, 0.2);
 
-    &.light {
+    [data-agentation-theme="light"] & {
       color: rgba(0, 0, 0, 0.2);
     }
   }
@@ -1661,7 +1695,7 @@ $green: #34c759;
     transform: scale(1);
   }
 
-  &.light {
+  [data-agentation-theme="light"] & {
     background: rgba(0, 0, 0, 0.2);
 
     &.active {
@@ -1723,7 +1757,7 @@ $green: #34c759;
   align-items: center;
   gap: 0.125rem;
 
-  &.light {
+  [data-agentation-theme="light"] & {
     color: rgba(0, 0, 0, 0.5);
   }
 }
@@ -1761,8 +1795,12 @@ $green: #34c759;
   }
 
   &.selected {
-    background: rgba($blue, 0.15);
-    color: $blue;
+    background: color-mix(
+      in srgb,
+      var(--agentation-color-blue) 15%,
+      transparent
+    );
+    color: var(--agentation-color-blue);
   }
 }
 
@@ -1854,8 +1892,13 @@ $green: #34c759;
   height: 20px;
   border-radius: 50%;
   border: 2px solid transparent;
+  background-color: var(--swatch);
   cursor: pointer;
   transition: transform 0.2s cubic-bezier(0.25, 1, 0.5, 1);
+
+  @supports (color: color(display-p3 0 0 0)) {
+    background-color: var(--swatch-p3);
+  }
 
   &:hover {
     transform: scale(1.15);
@@ -1863,7 +1906,6 @@ $green: #34c759;
 
   &.selected {
     transform: scale(0.83);
-    // border-color: rgba(255, 255, 255, 0.4);
   }
 }
 
@@ -1876,6 +1918,11 @@ $green: #34c759;
   transition: border-color 0.3s ease;
 
   &.selected {
+    border-color: var(--swatch);
+
+    @supports (color: color(display-p3 0 0 0)) {
+      border-color: var(--swatch-p3);
+    }
   }
 }
 
@@ -1913,7 +1960,7 @@ $green: #34c759;
   justify-content: center;
   flex-shrink: 0;
   transition:
-    background 0.25s ease,
+    background-color 0.25s ease,
     border-color 0.25s ease;
 
   svg {
@@ -1928,7 +1975,7 @@ $green: #34c759;
   }
 
   // Light mode variant (unchecked state)
-  &.light {
+  [data-agentation-theme="light"] & {
     border: 1px solid rgba(0, 0, 0, 0.15);
     background: #fff;
 
@@ -1953,7 +2000,7 @@ $green: #34c759;
   align-items: center;
   gap: 0.25rem;
 
-  &.light {
+  [data-agentation-theme="light"] & {
     color: rgba(0, 0, 0, 0.5);
   }
 }
@@ -1966,7 +2013,9 @@ $green: #34c759;
   height: 16px;
   flex-shrink: 0;
   cursor: pointer;
-  transition: opacity 0.15s ease;
+  transition:
+    background-color 0.2s cubic-bezier(0.4, 0, 0.2, 1),
+    opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1);
 
   input {
     opacity: 0;
@@ -1975,7 +2024,7 @@ $green: #34c759;
   }
 
   input:checked + .toggleSlider {
-    background: $blue;
+    background-color: var(--agentation-color-blue);
   }
 
   input:checked + .toggleSlider::before {
@@ -1999,7 +2048,7 @@ $green: #34c759;
   border-radius: 16px;
   background: #484848; // Dark mode unchecked
 
-  .light & {
+  [data-agentation-theme="light"] & {
     background: #dddddd; // Light mode unchecked
   }
 
@@ -2013,32 +2062,39 @@ $green: #34c759;
     background: white;
     border-radius: 50%;
     transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
   }
 }
 
 // MCP Status Dot
 @keyframes mcpPulse {
   0% {
-    box-shadow: 0 0 0 0 rgba($green, 0.5);
+    box-shadow: 0 0 0 0
+      color-mix(in srgb, var(--agentation-color-green) 50%, transparent);
   }
   70% {
-    box-shadow: 0 0 0 6px rgba($green, 0);
+    box-shadow: 0 0 0 6px
+      color-mix(in srgb, var(--agentation-color-green) 0%, transparent);
   }
   100% {
-    box-shadow: 0 0 0 0 rgba($green, 0);
+    box-shadow: 0 0 0 0
+      color-mix(in srgb, var(--agentation-color-green) 0%, transparent);
   }
 }
 
 @keyframes mcpPulseError {
   0% {
-    box-shadow: 0 0 0 0 rgba($red, 0.5);
+    box-shadow: 0 0 0 0
+      color-mix(in srgb, var(--agentation-color-red) 50%, transparent);
   }
+
   70% {
-    box-shadow: 0 0 0 6px rgba($red, 0);
+    box-shadow: 0 0 0 6px
+      color-mix(in srgb, var(--agentation-color-red) 0%, transparent);
   }
+
   100% {
-    box-shadow: 0 0 0 0 rgba($red, 0);
+    box-shadow: 0 0 0 0
+      color-mix(in srgb, var(--agentation-color-red) 0%, transparent);
   }
 }
 
@@ -2050,56 +2106,20 @@ $green: #34c759;
 
   // Connecting state
   &.connecting {
-    background: #f5a623;
+    background-color: var(--agentation-color-yellow);
     animation: mcpPulse 1.5s infinite;
   }
 
   // Connected state - subtle pulse
   &.connected {
-    background: $green;
+    background-color: var(--agentation-color-green);
     animation: mcpPulse 2.5s ease-in-out infinite;
   }
 
   // Disconnected/error state
   &.disconnected {
-    background: $red;
+    background-color: var(--agentation-color-red);
     animation: mcpPulseError 2s infinite;
-  }
-}
-
-.helpIcon {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: help;
-  margin-left: 0;
-
-  svg {
-    display: block;
-    transform: translateY(1px);
-    color: rgba(255, 255, 255, 0.2);
-    transition: color 0.15s ease;
-  }
-
-  &:hover svg {
-    color: rgba(255, 255, 255, 0.5);
-  }
-
-  &.helpIconNudgeDown svg {
-    transform: translateY(1px);
-  }
-
-  &.helpIconNoNudge svg {
-    transform: translateY(0.5px);
-  }
-
-  &.helpIconNudge1-5 svg {
-    transform: translateY(1.5px);
-  }
-
-  &.helpIconNudge2 svg {
-    transform: translateY(2px);
   }
 }
 
@@ -2111,9 +2131,14 @@ $green: #34c759;
   position: fixed;
   top: 0;
   left: 0;
-  border: 2px solid rgba($green, 0.6);
+  border: 2px solid
+    color-mix(in srgb, var(--agentation-color-green) 60%, transparent);
   border-radius: 4px;
-  background: rgba($green, 0.08);
+  background-color: color-mix(
+    in srgb,
+    var(--agentation-color-green) 8%,
+    transparent
+  );
   pointer-events: none;
   z-index: 99997;
   will-change: transform, width, height;
@@ -2125,7 +2150,7 @@ $green: #34c759;
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
-  background: $green;
+  background-color: var(--agentation-color-green);
   color: white;
   font-size: 0.875rem;
   font-weight: 600;
@@ -2147,9 +2172,10 @@ $green: #34c759;
   position: fixed;
   top: 0;
   left: 0;
-  border: 2px solid rgba($green, 0.5);
+  border: 2px solid
+    color-mix(in srgb, var(--agentation-color-green) 50%, transparent);
   border-radius: 4px;
-  background: rgba($green, 0.06);
+  background: color-mix(in srgb, var(--agentation-color-green) 6%, transparent);
   pointer-events: none;
   will-change: transform, width, height;
   contain: layout style;
@@ -2159,9 +2185,9 @@ $green: #34c759;
 // Light Mode
 // =============================================================================
 
-.light {
+[data-agentation-theme="light"] {
   // Toolbar container
-  &.toolbarContainer {
+  .toolbarContainer {
     background: #fff;
     color: rgba(0, 0, 0, 0.85);
     box-shadow:
@@ -2175,47 +2201,65 @@ $green: #34c759;
   }
 
   // Control buttons in toolbar
-  &.controlButton {
+  .controlButton {
     color: rgba(0, 0, 0, 0.5);
 
     &:hover:not(:disabled):not([data-active="true"]):not(
         [data-failed="true"]
-      ):not([data-auto-sync="true"]):not([data-error="true"]):not([data-no-hover="true"]) {
+      ):not([data-auto-sync="true"]):not([data-error="true"]):not(
+        [data-no-hover="true"]
+      ) {
       background: rgba(0, 0, 0, 0.06);
       color: rgba(0, 0, 0, 0.85);
     }
 
     &[data-active="true"] {
-      color: $blue;
-      background: rgba($blue, 0.15);
+      color: var(--agentation-color-blue);
+      background: color-mix(
+        in srgb,
+        var(--agentation-color-blue) 15%,
+        transparent
+      );
     }
 
-    &[data-error="true"] {
-      color: $red;
-      background: rgba($red, 0.15);
+    [data-error="true"] {
+      color: var(--agentation-color-red);
+      background: color-mix(
+        in srgb,
+        var(--agentation-color-red) 15%,
+        transparent
+      );
     }
 
-    &[data-danger]:hover:not(:disabled):not([data-active="true"]):not(
+    [data-danger]:hover:not(:disabled):not([data-active="true"]):not(
         [data-failed="true"]
       ) {
-      background: rgba($red, 0.15);
-      color: $red;
+      color: var(--agentation-color-red);
+      background: color-mix(
+        in srgb,
+        var(--agentation-color-red) 15%,
+        transparent
+      );
     }
 
-    &[data-auto-sync="true"] {
-      color: $green;
+    [data-auto-sync="true"] {
+      color: var(--agentation-color-green);
       background: transparent;
     }
 
-    // Failed state (no listeners) - red like danger hover
-    &[data-failed="true"] {
-      color: $red;
-      background: rgba($red, 0.15);
+    // Failed state (no listeners)
+    [data-failed="true"] {
+      color: var(--agentation-color-red);
+      background: color-mix(
+        in srgb,
+        var(--agentation-color-red) 15%,
+        transparent
+      );
     }
   }
 
   // Button tooltips
-  &.buttonTooltip {
+  .buttonTooltip {
     background: #fff;
     color: rgba(0, 0, 0, 0.85);
     box-shadow:
@@ -2229,12 +2273,12 @@ $green: #34c759;
   }
 
   // Divider
-  &.divider {
+  .divider {
     background: rgba(0, 0, 0, 0.1);
   }
 
   // Marker tooltip
-  &.markerTooltip {
+  .markerTooltip {
     background: #fff;
     box-shadow:
       0 4px 20px rgba(0, 0, 0, 0.12),
@@ -2254,7 +2298,7 @@ $green: #34c759;
   }
 
   // Settings panel
-  &.settingsPanel {
+  .settingsPanel {
     background: #fff;
     box-shadow:
       0 2px 8px rgba(0, 0, 0, 0.08),
@@ -2275,10 +2319,6 @@ $green: #34c759;
 
     .settingsBrand {
       color: rgba(0, 0, 0, 0.85);
-    }
-
-    .settingsBrandSlash {
-      color: rgba(0, 0, 0, 0.4);
     }
 
     .settingsVersion {
@@ -2354,14 +2394,6 @@ $green: #34c759;
         background: #1a1a1a;
       }
     }
-
-    .helpIcon svg {
-      color: rgba(0, 0, 0, 0.2);
-    }
-
-    .helpIcon:hover svg {
-      color: rgba(0, 0, 0, 0.5);
-    }
   }
 }
 
@@ -2387,7 +2419,7 @@ $green: #34c759;
     color: rgba(255, 255, 255, 0.8);
   }
 
-  .light & {
+  [data-agentation-theme="light"] & {
     color: rgba(0, 0, 0, 0.4);
 
     &:hover {

--- a/package/src/components/page-toolbar-css/styles.module.scss
+++ b/package/src/components/page-toolbar-css/styles.module.scss
@@ -861,12 +861,12 @@
 .multiSelectOutline {
   position: fixed;
   border: 2px dashed
-    color-mix(in srgb, var(--agentation-color-accent) 60%, transparent);
+    color-mix(in srgb, var(--agentation-color-green) 60%, transparent);
   border-radius: 4px;
   pointer-events: none !important;
   background-color: color-mix(
     in srgb,
-    var(--agentation-color-accent) 5%,
+    var(--agentation-color-green) 5%,
     transparent
   );
   box-sizing: border-box;
@@ -2222,7 +2222,7 @@
       );
     }
 
-    [data-error="true"] {
+    &[data-error="true"] {
       color: var(--agentation-color-red);
       background: color-mix(
         in srgb,
@@ -2231,7 +2231,7 @@
       );
     }
 
-    [data-danger]:hover:not(:disabled):not([data-active="true"]):not(
+    &[data-danger]:hover:not(:disabled):not([data-active="true"]):not(
         [data-failed="true"]
       ) {
       color: var(--agentation-color-red);
@@ -2242,13 +2242,13 @@
       );
     }
 
-    [data-auto-sync="true"] {
+    &[data-auto-sync="true"] {
       color: var(--agentation-color-green);
       background: transparent;
     }
 
     // Failed state (no listeners)
-    [data-failed="true"] {
+    &[data-failed="true"] {
       color: var(--agentation-color-red);
       background: color-mix(
         in srgb,

--- a/package/src/components/page-toolbar-css/styles.module.scss
+++ b/package/src/components/page-toolbar-css/styles.module.scss
@@ -372,7 +372,7 @@
   height: 18px;
   padding: 0 5px;
   border-radius: 9px;
-  background-color: var(--agentation-accent);
+  background-color: var(--agentation-color-accent);
   color: white;
   font-size: 0.625rem;
   font-weight: 600;
@@ -497,7 +497,7 @@
   height: 16px;
   padding: 0 4px;
   border-radius: 8px;
-  background-color: var(--agentation-accent);
+  background-color: var(--agentation-color-accent);
   color: white;
   font-size: 0.625rem;
   font-weight: 600;
@@ -841,11 +841,11 @@
 .hoverHighlight {
   position: fixed;
   border: 2px solid
-    color-mix(in srgb, var(--agentation-accent) 50%, transparent);
+    color-mix(in srgb, var(--agentation-color-accent) 50%, transparent);
   border-radius: 4px;
   background-color: color-mix(
     in srgb,
-    var(--agentation-accent) 4%,
+    var(--agentation-color-accent) 4%,
     transparent
   );
   pointer-events: none !important;
@@ -861,12 +861,12 @@
 .multiSelectOutline {
   position: fixed;
   border: 2px dashed
-    color-mix(in srgb, var(--agentation-accent) 60%, transparent);
+    color-mix(in srgb, var(--agentation-color-accent) 60%, transparent);
   border-radius: 4px;
   pointer-events: none !important;
   background-color: color-mix(
     in srgb,
-    var(--agentation-accent) 5%,
+    var(--agentation-color-accent) 5%,
     transparent
   );
   box-sizing: border-box;
@@ -1546,7 +1546,7 @@
 }
 
 .settingsBrandSlash {
-  color: var(--agentation-accent);
+  color: var(--agentation-color-accent);
   transition: color 0.2s ease;
 }
 

--- a/package/src/components/tooltip/index.tsx
+++ b/package/src/components/tooltip/index.tsx
@@ -1,0 +1,102 @@
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { originalSetTimeout } from "../../utils/freeze-animations";
+
+export const Tooltip = ({
+  content,
+  children,
+  ...props
+}: {
+  content: string;
+  children: React.ReactNode;
+} & React.HTMLAttributes<HTMLSpanElement>) => {
+  const [visible, setVisible] = useState(false);
+  const [shouldRender, setShouldRender] = useState(false);
+  const [position, setPosition] = useState({ top: 0, right: 0 });
+  const triggerRef = useRef<HTMLSpanElement>(null);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const exitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const updatePosition = () => {
+    if (triggerRef.current) {
+      const rect = triggerRef.current.getBoundingClientRect();
+      setPosition({
+        top: rect.top + rect.height / 2,
+        right: window.innerWidth - rect.left + 8,
+      });
+    }
+  };
+
+  const handleMouseEnter = () => {
+    setShouldRender(true);
+    if (exitTimeoutRef.current) {
+      clearTimeout(exitTimeoutRef.current);
+      exitTimeoutRef.current = null;
+    }
+    updatePosition();
+    timeoutRef.current = originalSetTimeout(() => {
+      setVisible(true);
+    }, 500);
+  };
+
+  const handleMouseLeave = () => {
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+    setVisible(false);
+    // Keep rendered during exit animation
+    exitTimeoutRef.current = originalSetTimeout(() => {
+      setShouldRender(false);
+    }, 150);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      if (exitTimeoutRef.current) clearTimeout(exitTimeoutRef.current);
+    };
+  }, []);
+
+  return (
+    <>
+      <span
+        ref={triggerRef}
+        onMouseEnter={handleMouseEnter}
+        onMouseLeave={handleMouseLeave}
+        {...props}
+      >
+        {children}
+      </span>
+      {shouldRender &&
+        createPortal(
+          <div
+            data-feedback-toolbar
+            style={{
+              position: "fixed",
+              top: position.top,
+              right: position.right,
+              transform: "translateY(-50%)",
+              padding: "6px 10px",
+              background: "#383838",
+              color: "rgba(255, 255, 255, 0.7)",
+              fontSize: "11px",
+              fontWeight: 400,
+              lineHeight: "14px",
+              borderRadius: "10px",
+              width: "180px",
+              textAlign: "left" as const,
+              zIndex: 100020,
+              pointerEvents: "none" as const,
+              boxShadow: "0px 1px 8px rgba(0, 0, 0, 0.28)",
+              opacity: visible ? 1 : 0,
+              transition: "opacity 0.15s ease",
+            }}
+          >
+            {content}
+          </div>,
+          document.body
+        )}
+    </>
+  );
+};


### PR DESCRIPTION
**Color system**
- `annotationColor` (hex string) replaced with `annotationColorId` in settings
- `COLOR_OPTIONS` updated and now includes `srgb` and `p3` fields for wide-gamut display support
- Color tokens injected at module level via `injectAgentationColorTokens()` — generates `--agentation-color-{id}` CSS variables on `:root` and `--agentation-color-accent` on `[data-agentation-accent]`
- `data-agentation-accent` attribute added to portal wrapper to drive the accent color via CSS
- All hardcoded hex colors replaced with CSS variables
- `$blue`, `$red`, `$green` SCSS variables removed entirely

**Theme refactor**
- `data-agentation-theme` attribute added to portal wrapper
- All `${!isDarkMode ? styles.light : ""}` class conditionals removed from JSX (~25 instances)
- `.light` CSS class selectors replaced with `[data-agentation-theme="light"]` attribute selectors
- `disableTransitions` utility class added to suppress flash during theme toggle
- `toggleTheme` replaces direct `setIsDarkMode` call

**Component extraction**
- Inline `Tooltip` component removed from `PageFeedbackToolbarCSS` and extracted to `components/tooltip/`
- New `HelpTooltip` component wraps `Tooltip` + `IconHelp`, replacing all `<span className={styles.helpIcon}>` patterns
- `IconHelp` SVG updated
- `.helpIcon` CSS class and its nudge variants deleted

**Settings page transition**
- Slide animation simplified from full-width to subtle push
- `isTransitioning` state and associated `useEffect` removed

**Bug fix**
- `suppressHydrationWarning` added to `HeroDemo` style tag fixing SSR hydration mismatch