### PR TITLE
fix: layout mode animations

### DIFF
--- a/package/src/components/design-mode/index.tsx
+++ b/package/src/components/design-mode/index.tsx
@@ -5,6 +5,7 @@ import { COMPONENT_MAP, DEFAULT_SIZES, type ComponentType, type DesignPlacement 
 import { Skeleton } from "./skeletons";
 import { AnnotationPopupCSS } from "../annotation-popup-css";
 import styles from "./styles.module.scss";
+import { originalSetTimeout } from "../../utils/freeze-animations";
 
 // =============================================================================
 // Layout Mode Overlay
@@ -182,7 +183,7 @@ export function DesignMode({
         setExitingIds(allIds);
         setSelectedIds(new Set());
         interactionRef.current = null;
-        setTimeout(() => {
+        originalSetTimeout(() => {
           onChange([]);
           setExitingIds(new Set());
         }, 180);
@@ -206,7 +207,7 @@ export function DesignMode({
         const toDelete = new Set(selectedIds);
         setExitingIds(toDelete);
         setSelectedIds(new Set());
-        setTimeout(() => {
+        originalSetTimeout(() => {
           onChange(placementsRef.current.filter((p) => !toDelete.has(p.id)));
           setExitingIds(new Set());
         }, 180);
@@ -602,7 +603,7 @@ export function DesignMode({
         next.delete(id);
         return next;
       });
-      setTimeout(() => {
+      originalSetTimeout(() => {
         onChange(placementsRef.current.filter((p) => p.id !== id));
         setExitingIds((prev) => {
           const next = new Set(prev);
@@ -649,7 +650,7 @@ export function DesignMode({
   const dismissEdit = useCallback(() => {
     if (!editingId) return;
     setEditExiting(true);
-    setTimeout(() => { setEditingId(null); setEditExiting(false); }, 150);
+    originalSetTimeout(() => { setEditingId(null); setEditExiting(false); }, 150);
   }, [editingId]);
 
   // Dismiss popup when overlay starts exiting

--- a/package/src/components/design-mode/palette.tsx
+++ b/package/src/components/design-mode/palette.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { COMPONENT_REGISTRY, DEFAULT_SIZES, type ComponentType } from "./types";
+import { originalRequestAnimationFrame, originalSetTimeout } from "../../utils/freeze-animations";
 import styles from "./styles.module.scss";
 
 function scrollFadeClass(el: HTMLDivElement | null) {
@@ -684,7 +685,7 @@ function RollingCount({ value, suffix }: { value: number; suffix?: string }) {
   const [dir, setDir] = useState<"up" | "down">("up");
   const cur = useRef(value);
   const curSuffix = useRef(suffix);
-  const timer = useRef<ReturnType<typeof setTimeout>>();
+  const timer = useRef<ReturnType<typeof originalSetTimeout>>();
 
   const suffixChanged = prev !== null && prevSuffix !== suffix;
 
@@ -703,7 +704,7 @@ function RollingCount({ value, suffix }: { value: number; suffix?: string }) {
       cur.current = value;
       curSuffix.current = suffix;
       clearTimeout(timer.current);
-      timer.current = setTimeout(() => setPrev(null), 250);
+      timer.current = originalSetTimeout(() => setPrev(null), 250);
     } else {
       curSuffix.current = suffix;
     }
@@ -778,7 +779,7 @@ export function DesignPalette({
   const lastFooterCount = useRef(0);
   const lastFooterSuffix = useRef("");
   const rafRef = useRef(0);
-  const exitTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const exitTimerRef = useRef<ReturnType<typeof originalSetTimeout>>();
   const placeScrollRef = useRef<HTMLDivElement>(null);
   const [placeFade, setPlaceFade] = useState("");
 
@@ -787,8 +788,8 @@ export function DesignPalette({
       setMounted(true);
       clearTimeout(exitTimerRef.current);
       cancelAnimationFrame(rafRef.current);
-      rafRef.current = requestAnimationFrame(() => {
-        rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = originalRequestAnimationFrame(() => {
+        rafRef.current = originalRequestAnimationFrame(() => {
           setAnimClass("enter");
         });
       });
@@ -796,7 +797,7 @@ export function DesignPalette({
       cancelAnimationFrame(rafRef.current);
       setAnimClass("exit");
       clearTimeout(exitTimerRef.current);
-      exitTimerRef.current = setTimeout(() => {
+      exitTimerRef.current = originalSetTimeout(() => {
         setMounted(false);
         onExited?.();
       }, 200);
@@ -816,8 +817,8 @@ export function DesignPalette({
       if (!footerVisible) {
         setFooterCollapsed(true);
         setFooterVisible(true);
-        requestAnimationFrame(() => {
-          requestAnimationFrame(() => {
+        originalRequestAnimationFrame(() => {
+          originalRequestAnimationFrame(() => {
             setFooterCollapsed(false);
           });
         });
@@ -826,7 +827,7 @@ export function DesignPalette({
       }
     } else {
       setFooterCollapsed(true);
-      const t = setTimeout(() => setFooterVisible(false), 300);
+      const t = originalSetTimeout(() => setFooterVisible(false), 300);
       return () => clearTimeout(t);
     }
   }, [hasFooterContent]);

--- a/package/src/components/design-mode/rearrange.tsx
+++ b/package/src/components/design-mode/rearrange.tsx
@@ -5,6 +5,7 @@ import { captureElement } from "./section-detection";
 import { AnnotationPopupCSS } from "../annotation-popup-css";
 import type { DetectedSection, RearrangeState } from "./types";
 import styles from "./styles.module.scss";
+import { originalSetTimeout } from "../../utils/freeze-animations";
 
 // =============================================================================
 // Rearrange Overlay — Click-to-capture, free drag, resize
@@ -173,7 +174,7 @@ export function RearrangeOverlay({ rearrangeState, onChange, isDarkMode, exiting
   const dismissEdit = useCallback(() => {
     if (!editingId) return;
     setEditExiting(true);
-    setTimeout(() => { setEditingId(null); setEditExiting(false); }, 150);
+    originalSetTimeout(() => { setEditingId(null); setEditExiting(false); }, 150);
   }, [editingId]);
 
   const submitEdit = useCallback((text: string) => {
@@ -231,7 +232,7 @@ export function RearrangeOverlay({ rearrangeState, onChange, isDarkMode, exiting
   );
   useEffect(() => {
     if (!outlinesReady) {
-      const timer = setTimeout(() => setOutlinesReady(true), 380);
+      const timer = originalSetTimeout(() => setOutlinesReady(true), 380);
       return () => clearTimeout(timer);
     }
   }, []); // only on mount
@@ -432,7 +433,7 @@ export function RearrangeOverlay({ rearrangeState, onChange, isDarkMode, exiting
         const idsToDelete = new Set(selectedIds);
         setExitingIds(prev => { const next = new Set(prev); for (const id of idsToDelete) next.add(id); return next; });
         setSelectedIds(new Set());
-        setTimeout(() => {
+        originalSetTimeout(() => {
           const rs = rearrangeStateRef.current;
           onChange({
             ...rs,
@@ -709,7 +710,7 @@ export function RearrangeOverlay({ rearrangeState, onChange, isDarkMode, exiting
     (id: string) => {
       setExitingIds(prev => { const next = new Set(prev); next.add(id); return next; });
       setSelectedIds(prev => { const next = new Set(prev); next.delete(id); return next; });
-      setTimeout(() => {
+      originalSetTimeout(() => {
         const rs = rearrangeStateRef.current;
         onChange({
           ...rs,
@@ -799,7 +800,7 @@ export function RearrangeOverlay({ rearrangeState, onChange, isDarkMode, exiting
         for (const [id, data] of exiting) next.set(id, data);
         return next;
       });
-      const timer = setTimeout(() => {
+      const timer = originalSetTimeout(() => {
         setExitingConnectors(prev => {
           const next = new Map(prev);
           for (const id of exiting.keys()) next.delete(id);

--- a/package/src/components/page-toolbar-css/index.tsx
+++ b/package/src/components/page-toolbar-css/index.tsx
@@ -80,6 +80,7 @@ import {
   unfreeze as unfreezeAll,
   originalSetTimeout,
   originalSetInterval,
+  originalRequestAnimationFrame,
 } from "../../utils/freeze-animations";
 
 import type { Annotation } from "../../types";
@@ -461,14 +462,14 @@ export function PageFeedbackToolbarCSS({
   const rearrangeSelectedIdsRef = useRef<Set<string>>(new Set());
   // Track start positions for cross-drag (set when drag starts)
   const crossDragStartRef = useRef<Map<string, { x: number; y: number }> | null>(null);
-  const designExitTimer = useRef<ReturnType<typeof setTimeout>>();
+  const designExitTimer = useRef<ReturnType<typeof originalSetTimeout>>();
 
   // Delay blank canvas .visible by one frame when becoming visible so CSS transition fires
   const canvasShouldBeVisible = isDesignMode && isActive && !designOverlayExiting && blankCanvas;
   useEffect(() => {
     if (canvasShouldBeVisible) {
       setCanvasReady(false);
-      const raf = requestAnimationFrame(() => {
+      const raf = originalRequestAnimationFrame(() => {
         setCanvasReady(true);
       });
       return () => cancelAnimationFrame(raf);
@@ -480,7 +481,7 @@ export function PageFeedbackToolbarCSS({
   // Shadow annotation tracking (design → server sync)
   const placementAnnotationMap = useRef(new Map<string, string>()); // placementId → server annotationId
   const rearrangeAnnotationMap = useRef(new Map<string, string>()); // sectionId → server annotationId
-  const rearrangeDebounceTimer = useRef<ReturnType<typeof setTimeout>>();
+  const rearrangeDebounceTimer = useRef<ReturnType<typeof originalSetTimeout>>();
 
   // Draw mode state
   const [isDrawMode, setIsDrawMode] = useState(false);
@@ -497,7 +498,7 @@ export function PageFeedbackToolbarCSS({
   const exitingAlphaRef = useRef(1);
 
   const [tooltipSessionActive, setTooltipSessionActive] = useState(false);
-  const tooltipSessionTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
+  const tooltipSessionTimerRef = useRef<ReturnType<typeof originalSetTimeout> | null>(
     null,
   );
 
@@ -524,7 +525,7 @@ export function PageFeedbackToolbarCSS({
 
   const handleControlsMouseEnter = () => {
     if (!tooltipSessionActive) {
-      tooltipSessionTimerRef.current = setTimeout(
+      tooltipSessionTimerRef.current = originalSetTimeout(
         () => setTooltipSessionActive(true),
         850,
       );
@@ -567,7 +568,7 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
   const toggleTheme = () => {
     portalWrapperRef.current?.classList.add(styles.disableTransitions);
     setIsDarkMode((previous) => !previous);
-    requestAnimationFrame(() => {
+    originalRequestAnimationFrame(() => {
       portalWrapperRef.current?.classList.remove(styles.disableTransitions);
     });
   }
@@ -627,7 +628,7 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
 
   const popupRef = useRef<AnnotationPopupCSSHandle>(null);
   const editPopupRef = useRef<AnnotationPopupCSSHandle>(null);
-  const scrollTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scrollTimeoutRef = useRef<ReturnType<typeof originalSetTimeout> | null>(null);
 
   const pathname =
     typeof window !== "undefined" ? window.location.pathname : "/";
@@ -1145,7 +1146,7 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
     if (!mounted || !demoAnnotations || demoAnnotations.length === 0) return;
     if (annotations.length > 0) return;
 
-    const timeoutIds: ReturnType<typeof setTimeout>[] = [];
+    const timeoutIds: ReturnType<typeof originalSetTimeout>[] = [];
 
     timeoutIds.push(
       originalSetTimeout(() => {
@@ -1599,7 +1600,7 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
         el.style.position = origStyles.position;
         el.style.zIndex = origStyles.zIndex;
         // Clean up transition + display + ancestors after animation completes
-        setTimeout(() => {
+        originalSetTimeout(() => {
           el.style.transition = "";
           el.style.display = origStyles.display;
           for (const a of ancestors) {
@@ -1619,7 +1620,7 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
     // Don't reset subMode here — it causes a crossfade during exit animation.
     // It stays on the last-used tab for next time.
     clearTimeout(designExitTimer.current);
-    designExitTimer.current = setTimeout(() => {
+    designExitTimer.current = originalSetTimeout(() => {
       setDesignOverlayExiting(false);
     }, 300);
   }, []);
@@ -1631,7 +1632,7 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
       setIsDesignMode(false);
       setActiveDesignComponent(null);
       clearTimeout(designExitTimer.current);
-      designExitTimer.current = setTimeout(() => {
+      designExitTimer.current = originalSetTimeout(() => {
         setDesignOverlayExiting(false);
       }, 300);
     }

--- a/package/src/components/tooltip/index.tsx
+++ b/package/src/components/tooltip/index.tsx
@@ -14,8 +14,8 @@ export const Tooltip = ({
   const [shouldRender, setShouldRender] = useState(false);
   const [position, setPosition] = useState({ top: 0, right: 0 });
   const triggerRef = useRef<HTMLSpanElement>(null);
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const exitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const timeoutRef = useRef<ReturnType<typeof originalSetTimeout> | null>(null);
+  const exitTimeoutRef = useRef<ReturnType<typeof originalSetTimeout> | null>(null);
 
   const updatePosition = () => {
     if (triggerRef.current) {

--- a/package/src/utils/freeze-animations.ts
+++ b/package/src/utils/freeze-animations.ts
@@ -143,6 +143,7 @@ if (typeof window !== "undefined" && !_s.installed) {
 // ---------------------------------------------------------------------------
 export const originalSetTimeout = _s.origSetTimeout;
 export const originalSetInterval = _s.origSetInterval;
+export const originalRequestAnimationFrame = _s.origRAF;
 
 // ---------------------------------------------------------------------------
 // Freeze / Unfreeze


### PR DESCRIPTION
Export `originalRequestAnimationFrame` from `freeze-animations.ts`, and replace all usages of `requestAnimationFrame` with it. Same for `setTimeout`, using `originalSetTimeout`.