### PR TITLE
Fix CSS overflow in textarea, settings page, and color swatches

### DIFF
--- a/package/src/components/annotation-popup-css/styles.module.scss
+++ b/package/src/components/annotation-popup-css/styles.module.scss
@@ -233,6 +233,7 @@
 // =============================================================================
 
 .textarea {
+  box-sizing: border-box;
   width: 100%;
   padding: 0.5rem 0.625rem;
   font-size: 0.8125rem;

--- a/package/src/components/page-toolbar-css/settings-panel/styles.module.scss
+++ b/package/src/components/page-toolbar-css/settings-panel/styles.module.scss
@@ -184,6 +184,7 @@
 
 .settingsPage {
   min-width: 100%;
+  flex-basis: 0;
   flex-shrink: 0;
   transition:
     transform 0.2s ease,
@@ -421,6 +422,7 @@
 }
 
 .colorOption {
+  padding: 0;
   position: relative;
   border-radius: 50%;
   width: 20px;


### PR DESCRIPTION
## Summary
- Add `box-sizing: border-box` to annotation popup textarea — padding and border were causing it to exceed its container width
- Add `flex-basis: 0` to `.settingsPage` — prevents flex item from overflowing the settings panel
- Add `padding: 0` to `.colorOption` button — resets default browser button padding that made the 20×20px color swatches too wide