### PR TITLE
feat: use shadow dom

### DIFF
--- a/package/example/public/design-mode.html
+++ b/package/example/public/design-mode.html
@@ -68,7 +68,7 @@ html, body { height: 100%; overflow: hidden; font-family: 'Inter', -apple-system
 .palette-section-title { font-size: 10px; font-weight: 600; color: var(--text-3); text-transform: uppercase; letter-spacing: 0.08em; padding: 0 6px; margin-bottom: 8px; }
 .palette-item {
   display: flex; align-items: center; gap: 10px; padding: 8px 10px; border-radius: 8px;
-  cursor: grab; transition: all 0.15s; border: 1px solid transparent; user-select: none;
+  cursor: grab; transition: all 0.15s; border: 1px solid transparent; -webkit-user-select: none; user-select: none;
 }
 .palette-item:hover { background: var(--surface-2); border-color: var(--border); }
 .palette-item.selected { background: var(--accent-dim); border-color: var(--accent); }

--- a/package/package.json
+++ b/package/package.json
@@ -49,6 +49,7 @@
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "esbuild": "^0.27.4",
     "esbuild-sass-plugin": "^3.6.0",
     "jsdom": "^25.0.0",
     "postcss": "^8.5.6",

--- a/package/pnpm-lock.yaml
+++ b/package/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.0
         version: 4.7.0(vite@5.4.21(@types/node@20.19.30)(sass-embedded@1.97.2)(sass@1.97.2))
+      esbuild:
+        specifier: ^0.27.4
+        version: 0.27.4
       esbuild-sass-plugin:
         specifier: ^3.6.0
         version: 3.6.0(esbuild@0.27.2)(sass-embedded@1.97.2)
@@ -67,7 +70,7 @@ importers:
         version: 12.28.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       next:
         specifier: ^14.0.0
-        version: 14.2.35(@babel/core@7.28.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.2)
+        version: 14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.2)
       prism-react-renderer:
         specifier: ^2.4.1
         version: 2.4.1(react@18.3.1)
@@ -236,6 +239,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.4':
+    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.21.5':
     resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
     engines: {node: '>=12'}
@@ -244,6 +253,12 @@ packages:
 
   '@esbuild/android-arm64@0.27.2':
     resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.4':
+    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -260,6 +275,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.4':
+    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.21.5':
     resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
     engines: {node: '>=12'}
@@ -268,6 +289,12 @@ packages:
 
   '@esbuild/android-x64@0.27.2':
     resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.4':
+    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -284,6 +311,12 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.4':
+    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.21.5':
     resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
     engines: {node: '>=12'}
@@ -292,6 +325,12 @@ packages:
 
   '@esbuild/darwin-x64@0.27.2':
     resolution: {integrity: sha512-ZxtijOmlQCBWGwbVmwOF/UCzuGIbUkqB1faQRf5akQmxRJ1ujusWsb3CVfk/9iZKr2L5SMU5wPBi1UWbvL+VQA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.4':
+    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -308,6 +347,12 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.4':
+    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.21.5':
     resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
     engines: {node: '>=12'}
@@ -316,6 +361,12 @@ packages:
 
   '@esbuild/freebsd-x64@0.27.2':
     resolution: {integrity: sha512-tAfqtNYb4YgPnJlEFu4c212HYjQWSO/w/h/lQaBK7RbwGIkBOuNKQI9tqWzx7Wtp7bTPaGC6MJvWI608P3wXYA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.4':
+    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -332,6 +383,12 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.4':
+    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.21.5':
     resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
     engines: {node: '>=12'}
@@ -340,6 +397,12 @@ packages:
 
   '@esbuild/linux-arm@0.27.2':
     resolution: {integrity: sha512-vWfq4GaIMP9AIe4yj1ZUW18RDhx6EPQKjwe7n8BbIecFtCQG4CfHGaHuh7fdfq+y3LIA2vGS/o9ZBGVxIDi9hw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.4':
+    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -356,6 +419,12 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.4':
+    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.21.5':
     resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
     engines: {node: '>=12'}
@@ -364,6 +433,12 @@ packages:
 
   '@esbuild/linux-loong64@0.27.2':
     resolution: {integrity: sha512-lugyF1atnAT463aO6KPshVCJK5NgRnU4yb3FUumyVz+cGvZbontBgzeGFO1nF+dPueHD367a2ZXe1NtUkAjOtg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.4':
+    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -380,6 +455,12 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.4':
+    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.21.5':
     resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
     engines: {node: '>=12'}
@@ -388,6 +469,12 @@ packages:
 
   '@esbuild/linux-ppc64@0.27.2':
     resolution: {integrity: sha512-C92gnpey7tUQONqg1n6dKVbx3vphKtTHJaNG2Ok9lGwbZil6DrfyecMsp9CrmXGQJmZ7iiVXvvZH6Ml5hL6XdQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.4':
+    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -404,6 +491,12 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.4':
+    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.21.5':
     resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
     engines: {node: '>=12'}
@@ -412,6 +505,12 @@ packages:
 
   '@esbuild/linux-s390x@0.27.2':
     resolution: {integrity: sha512-p4bm9+wsPwup5Z8f4EpfN63qNagQ47Ua2znaqGH6bqLlmJ4bx97Y9JdqxgGZ6Y8xVTixUnEkoKSHcpRlDnNr5w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.4':
+    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -428,8 +527,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.4':
+    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.2':
     resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -446,8 +557,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.4':
+    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.2':
     resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -464,8 +587,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.4':
+    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.2':
     resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.4':
+    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -482,6 +617,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.4':
+    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.21.5':
     resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
     engines: {node: '>=12'}
@@ -490,6 +631,12 @@ packages:
 
   '@esbuild/win32-arm64@0.27.2':
     resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.4':
+    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -506,6 +653,12 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.4':
+    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.21.5':
     resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
     engines: {node: '>=12'}
@@ -514,6 +667,12 @@ packages:
 
   '@esbuild/win32-x64@0.27.2':
     resolution: {integrity: sha512-sRdU18mcKf7F+YgheI/zGf5alZatMUTKj/jNS6l744f9u3WFu4v7twcUI9vu4mknF4Y9aDlblIie0IM+5xxaqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.4':
+    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1092,6 +1251,11 @@ packages:
 
   esbuild@0.27.2:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.27.4:
+    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2049,10 +2213,16 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.2':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.4':
+    optional: true
+
   '@esbuild/android-arm64@0.21.5':
     optional: true
 
   '@esbuild/android-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.4':
     optional: true
 
   '@esbuild/android-arm@0.21.5':
@@ -2061,10 +2231,16 @@ snapshots:
   '@esbuild/android-arm@0.27.2':
     optional: true
 
+  '@esbuild/android-arm@0.27.4':
+    optional: true
+
   '@esbuild/android-x64@0.21.5':
     optional: true
 
   '@esbuild/android-x64@0.27.2':
+    optional: true
+
+  '@esbuild/android-x64@0.27.4':
     optional: true
 
   '@esbuild/darwin-arm64@0.21.5':
@@ -2073,10 +2249,16 @@ snapshots:
   '@esbuild/darwin-arm64@0.27.2':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.4':
+    optional: true
+
   '@esbuild/darwin-x64@0.21.5':
     optional: true
 
   '@esbuild/darwin-x64@0.27.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.4':
     optional: true
 
   '@esbuild/freebsd-arm64@0.21.5':
@@ -2085,10 +2267,16 @@ snapshots:
   '@esbuild/freebsd-arm64@0.27.2':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.4':
+    optional: true
+
   '@esbuild/freebsd-x64@0.21.5':
     optional: true
 
   '@esbuild/freebsd-x64@0.27.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.4':
     optional: true
 
   '@esbuild/linux-arm64@0.21.5':
@@ -2097,10 +2285,16 @@ snapshots:
   '@esbuild/linux-arm64@0.27.2':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.4':
+    optional: true
+
   '@esbuild/linux-arm@0.21.5':
     optional: true
 
   '@esbuild/linux-arm@0.27.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.4':
     optional: true
 
   '@esbuild/linux-ia32@0.21.5':
@@ -2109,10 +2303,16 @@ snapshots:
   '@esbuild/linux-ia32@0.27.2':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.4':
+    optional: true
+
   '@esbuild/linux-loong64@0.21.5':
     optional: true
 
   '@esbuild/linux-loong64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.4':
     optional: true
 
   '@esbuild/linux-mips64el@0.21.5':
@@ -2121,10 +2321,16 @@ snapshots:
   '@esbuild/linux-mips64el@0.27.2':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.4':
+    optional: true
+
   '@esbuild/linux-ppc64@0.21.5':
     optional: true
 
   '@esbuild/linux-ppc64@0.27.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.4':
     optional: true
 
   '@esbuild/linux-riscv64@0.21.5':
@@ -2133,10 +2339,16 @@ snapshots:
   '@esbuild/linux-riscv64@0.27.2':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.4':
+    optional: true
+
   '@esbuild/linux-s390x@0.21.5':
     optional: true
 
   '@esbuild/linux-s390x@0.27.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.4':
     optional: true
 
   '@esbuild/linux-x64@0.21.5':
@@ -2145,7 +2357,13 @@ snapshots:
   '@esbuild/linux-x64@0.27.2':
     optional: true
 
+  '@esbuild/linux-x64@0.27.4':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.4':
     optional: true
 
   '@esbuild/netbsd-x64@0.21.5':
@@ -2154,7 +2372,13 @@ snapshots:
   '@esbuild/netbsd-x64@0.27.2':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.4':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.4':
     optional: true
 
   '@esbuild/openbsd-x64@0.21.5':
@@ -2163,7 +2387,13 @@ snapshots:
   '@esbuild/openbsd-x64@0.27.2':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.4':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.4':
     optional: true
 
   '@esbuild/sunos-x64@0.21.5':
@@ -2172,10 +2402,16 @@ snapshots:
   '@esbuild/sunos-x64@0.27.2':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.4':
+    optional: true
+
   '@esbuild/win32-arm64@0.21.5':
     optional: true
 
   '@esbuild/win32-arm64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.4':
     optional: true
 
   '@esbuild/win32-ia32@0.21.5':
@@ -2184,10 +2420,16 @@ snapshots:
   '@esbuild/win32-ia32@0.27.2':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.4':
+    optional: true
+
   '@esbuild/win32-x64@0.21.5':
     optional: true
 
   '@esbuild/win32-x64@0.27.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.4':
     optional: true
 
   '@jridgewell/gen-mapping@0.3.13':
@@ -2702,6 +2944,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.2
       '@esbuild/win32-x64': 0.27.2
 
+  esbuild@0.27.4:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.4
+      '@esbuild/android-arm': 0.27.4
+      '@esbuild/android-arm64': 0.27.4
+      '@esbuild/android-x64': 0.27.4
+      '@esbuild/darwin-arm64': 0.27.4
+      '@esbuild/darwin-x64': 0.27.4
+      '@esbuild/freebsd-arm64': 0.27.4
+      '@esbuild/freebsd-x64': 0.27.4
+      '@esbuild/linux-arm': 0.27.4
+      '@esbuild/linux-arm64': 0.27.4
+      '@esbuild/linux-ia32': 0.27.4
+      '@esbuild/linux-loong64': 0.27.4
+      '@esbuild/linux-mips64el': 0.27.4
+      '@esbuild/linux-ppc64': 0.27.4
+      '@esbuild/linux-riscv64': 0.27.4
+      '@esbuild/linux-s390x': 0.27.4
+      '@esbuild/linux-x64': 0.27.4
+      '@esbuild/netbsd-arm64': 0.27.4
+      '@esbuild/netbsd-x64': 0.27.4
+      '@esbuild/openbsd-arm64': 0.27.4
+      '@esbuild/openbsd-x64': 0.27.4
+      '@esbuild/openharmony-arm64': 0.27.4
+      '@esbuild/sunos-x64': 0.27.4
+      '@esbuild/win32-arm64': 0.27.4
+      '@esbuild/win32-ia32': 0.27.4
+      '@esbuild/win32-x64': 0.27.4
+
   escalade@3.2.0: {}
 
   estree-walker@3.0.3:
@@ -2919,7 +3190,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  next@14.2.35(@babel/core@7.28.6)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.2):
+  next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.2):
     dependencies:
       '@next/env': 14.2.35
       '@swc/helpers': 0.5.5
@@ -2929,7 +3200,7 @@ snapshots:
       postcss: 8.4.31
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      styled-jsx: 5.1.1(@babel/core@7.28.6)(react@18.3.1)
+      styled-jsx: 5.1.1(react@18.3.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 14.2.33
       '@next/swc-darwin-x64': 14.2.33
@@ -3235,12 +3506,10 @@ snapshots:
 
   string-hash@1.1.3: {}
 
-  styled-jsx@5.1.1(@babel/core@7.28.6)(react@18.3.1):
+  styled-jsx@5.1.1(react@18.3.1):
     dependencies:
       client-only: 0.0.1
       react: 18.3.1
-    optionalDependencies:
-      '@babel/core': 7.28.6
 
   sucrase@3.35.1:
     dependencies:

--- a/package/src/components/checkbox/index.tsx
+++ b/package/src/components/checkbox/index.tsx
@@ -2,10 +2,24 @@ import styles from "./styles.module.scss";
 
 interface CheckboxProps extends React.InputHTMLAttributes<HTMLInputElement> {}
 
-export const Checkbox = ({ className = "", ...props }: CheckboxProps) => {
+export const Checkbox = ({
+  className = "",
+  checked,
+  onChange,
+  ...props
+}: CheckboxProps) => {
   return (
-    <div className={`${styles.checkboxContainer} ${className}`}>
-      <input className={styles.checkboxInput} type="checkbox" {...props} />
+    <div
+      className={`${styles.checkboxContainer} ${className}`}
+      data-checked={checked ? "" : undefined}
+    >
+      <input
+        className={styles.checkboxInput}
+        type="checkbox"
+        checked={checked}
+        onChange={onChange}
+        {...props}
+      />
       <svg
         className={styles.checkboxCheck}
         width="14"

--- a/package/src/components/checkbox/styles.module.scss
+++ b/package/src/components/checkbox/styles.module.scss
@@ -51,7 +51,7 @@
     color: #1a1a1a;
   }
 
-  .checkboxContainer:has(.checkboxInput:checked) & {
+  .checkboxContainer[data-checked] & {
     transition-duration: 0.2s;
     stroke-dashoffset: 0;
   }

--- a/package/src/components/design-mode/rearrange.tsx
+++ b/package/src/components/design-mode/rearrange.tsx
@@ -6,6 +6,7 @@ import { AnnotationPopupCSS } from "../annotation-popup-css";
 import type { DetectedSection, RearrangeState } from "./types";
 import styles from "./styles.module.scss";
 import { originalSetTimeout } from "../../utils/freeze-animations";
+import { useShadowRoot } from "../../utils/use-shadow-root";
 
 // =============================================================================
 // Rearrange Overlay — Click-to-capture, free drag, resize
@@ -360,7 +361,7 @@ export function RearrangeOverlay({ rearrangeState, onChange, isDarkMode, exiting
           lastDy = snappedDy;
 
           // Ghost mode: only move outline (ghost preview), not the page element
-          const outlineEl = document.querySelector(`[data-rearrange-section="${section.id}"]`) as HTMLElement | null;
+          const outlineEl = shadowRoot.querySelector(`[data-rearrange-section="${section.id}"]`) as HTMLElement | null;
           if (outlineEl) outlineEl.style.transform = `translate(${snappedDx}px, ${snappedDy}px)`;
           // Update live drag position for connector lines
           setDragPositions(new Map([[section.id, { x: startPos.x + snappedDx, y: startPos.y + snappedDy, width: section.currentRect.width, height: section.currentRect.height }]]));
@@ -373,7 +374,7 @@ export function RearrangeOverlay({ rearrangeState, onChange, isDarkMode, exiting
           interactionRef.current = null;
           setSnapGuides([]);
           setDragPositions(new Map());
-          const outlineEl = document.querySelector(`[data-rearrange-section="${section.id}"]`) as HTMLElement | null;
+          const outlineEl = shadowRoot.querySelector(`[data-rearrange-section="${section.id}"]`) as HTMLElement | null;
           if (outlineEl) outlineEl.style.transform = "";
           if (moved) {
 
@@ -515,7 +516,7 @@ export function RearrangeOverlay({ rearrangeState, onChange, isDarkMode, exiting
       }>();
       for (const s of sections) {
         if (newSelected.has(s.id)) {
-          const outlineEl = document.querySelector(`[data-rearrange-section="${s.id}"]`) as HTMLElement | null;
+          const outlineEl = shadowRoot.querySelector(`[data-rearrange-section="${s.id}"]`) as HTMLElement | null;
           dragEls.set(s.id, {
             outlineEl,
             curW: s.currentRect.width, curH: s.currentRect.height,
@@ -637,7 +638,7 @@ export function RearrangeOverlay({ rearrangeState, onChange, isDarkMode, exiting
       let lastRect = { ...startRect };
 
       // Cache outline for direct updates — ghost mode, no page element transforms
-      const resizeOutlineEl = document.querySelector(`[data-rearrange-section="${id}"]`) as HTMLElement | null;
+      const resizeOutlineEl = shadowRoot.querySelector(`[data-rearrange-section="${id}"]`) as HTMLElement | null;
 
       const onMove = (ev: MouseEvent) => {
         const dx = ev.clientX - startX;
@@ -811,9 +812,14 @@ export function RearrangeOverlay({ rearrangeState, onChange, isDarkMode, exiting
     }
   }, [changedKey, sections]);
 
+  const overlayRef = useRef<HTMLDivElement>(null);
+
+  const shadowRoot = useShadowRoot(overlayRef);
+
   return (
     <>
       <div
+        ref={overlayRef}
         className={`${styles.rearrangeOverlay} ${!isDarkMode ? styles.light : ""} ${exiting ? styles.overlayExiting : ""}${extraClassName ? ` ${extraClassName}` : ""}`}
         data-feedback-toolbar
       >

--- a/package/src/components/design-mode/rearrange.tsx
+++ b/package/src/components/design-mode/rearrange.tsx
@@ -292,8 +292,12 @@ export function RearrangeOverlay({ rearrangeState, onChange, isDarkMode, exiting
   // --- Prevent text selection while rearrange mode is active ---
   useEffect(() => {
     const prev = document.body.style.userSelect;
+    document.body.style.webkitUserSelect = "none";
     document.body.style.userSelect = "none";
-    return () => { document.body.style.userSelect = prev; };
+    return () => { 
+      document.body.style.webkitUserSelect = prev;
+      document.body.style.userSelect = prev;
+    };
   }, []);
 
   // --- Mousedown to capture new elements (+ immediate drag) ---

--- a/package/src/components/design-mode/styles.module.scss
+++ b/package/src/components/design-mode/styles.module.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 // =============================================================================
 // Layout Mode Styles
 // =============================================================================
@@ -22,7 +24,6 @@ $red: #ef4444;
   transition: opacity 0.25s ease !important;
   pointer-events: none !important;
 }
-
 
 .overlay {
   position: fixed;
@@ -86,8 +87,11 @@ $red: #ef4444;
     content: "";
     position: absolute;
     inset: 0;
-    background-image:
-      radial-gradient(circle, rgba(0, 0, 0, 0.08) 1px, transparent 1px);
+    background-image: radial-gradient(
+      circle,
+      rgba(0, 0, 0, 0.08) 1px,
+      transparent 1px
+    );
     background-size: 24px 24px;
     background-position: 12px 12px;
     pointer-events: none;
@@ -96,8 +100,11 @@ $red: #ef4444;
 
   &.gridActive::after {
     opacity: 1;
-    background-image:
-      radial-gradient(circle, rgba(0, 0, 0, 0.22) 1px, transparent 1px);
+    background-image: radial-gradient(
+      circle,
+      rgba(0, 0, 0, 0.22) 1px,
+      transparent 1px
+    );
   }
 }
 
@@ -160,7 +167,9 @@ $red: #ef4444;
 .wireframePurposeWrap {
   display: grid;
   grid-template-rows: 1fr;
-  transition: grid-template-rows 0.2s ease, opacity 0.15s ease;
+  transition:
+    grid-template-rows 0.2s ease,
+    opacity 0.15s ease;
   opacity: 1;
 
   &.collapsed {
@@ -229,7 +238,9 @@ $red: #ef4444;
   cursor: pointer;
   border: 1px dashed rgba(255, 255, 255, 0.1);
   background: transparent;
-  transition: background 0.15s ease, border-color 0.15s ease;
+  transition:
+    background 0.15s ease,
+    border-color 0.15s ease;
 
   &:hover {
     background: rgba(255, 255, 255, 0.04);
@@ -301,121 +312,6 @@ $red: #ef4444;
   }
 }
 
-.canvasPurposeWrap {
-  display: grid;
-  grid-template-rows: 1fr;
-  transition: grid-template-rows 0.2s ease, opacity 0.15s ease;
-  opacity: 1;
-
-  &.collapsed {
-    grid-template-rows: 0fr;
-    opacity: 0;
-  }
-}
-
-.canvasPurposeInner {
-  overflow: hidden;
-}
-
-// Matches .settingsToggle from settings panel
-.canvasPurposeToggle {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  cursor: pointer;
-  margin: 0.375rem 1rem 0.375rem 1.1875rem;
-
-  input[type="checkbox"] {
-    position: absolute;
-    opacity: 0;
-    width: 0;
-    height: 0;
-  }
-}
-
-// Matches .customCheckbox from settings panel
-.canvasPurposeCheck {
-  position: relative;
-  width: 14px;
-  height: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 4px;
-  background: rgba(255, 255, 255, 0.05);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  transition: background 0.25s ease, border-color 0.25s ease;
-
-  svg {
-    color: #1a1a1a;
-    opacity: 1;
-    transition: opacity 0.15s ease;
-  }
-
-  &.checked {
-    border-color: rgba(255, 255, 255, 0.3);
-    background: rgba(255, 255, 255, 1);
-  }
-
-  .light & {
-    border: 1px solid rgba(0, 0, 0, 0.15);
-    background: #fff;
-
-    &.checked {
-      border-color: #1a1a1a;
-      background: #1a1a1a;
-
-      svg {
-        color: #fff;
-      }
-    }
-  }
-}
-
-// Matches .toggleLabel from settings panel
-.canvasPurposeLabel {
-  font-size: 0.8125rem;
-  font-weight: 400;
-  color: rgba(255, 255, 255, 0.5);
-  letter-spacing: -0.0094em;
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-
-  .light & {
-    color: rgba(0, 0, 0, 0.5);
-  }
-}
-
-// Matches .helpIcon from settings panel
-.canvasPurposeHelp {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  cursor: help;
-
-  svg {
-    color: rgba(255, 255, 255, 0.2);
-    transform: translateY(2px);
-    transition: color 0.15s ease;
-  }
-
-  &:hover svg {
-    color: rgba(255, 255, 255, 0.5);
-  }
-
-  .light & svg {
-    color: rgba(0, 0, 0, 0.2);
-  }
-
-  .light &:hover svg {
-    color: rgba(0, 0, 0, 0.5);
-  }
-
-}
-
 // =============================================================================
 // Placed Component
 // =============================================================================
@@ -426,7 +322,11 @@ $red: #ef4444;
   border-radius: 6px;
   background: rgba(59, 130, 246, 0.08);
   cursor: grab;
-  transition: box-shadow 0.15s, border-color 0.15s, opacity 0.15s ease, transform 0.15s ease;
+  transition:
+    box-shadow 0.15s,
+    border-color 0.15s,
+    opacity 0.15s ease,
+    transform 0.15s ease;
   user-select: none;
   pointer-events: auto;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
@@ -446,10 +346,14 @@ $red: #ef4444;
     border-color: $blue;
     border-style: solid;
     background: rgba(59, 130, 246, 0.1);
-    box-shadow: 0 0 0 2px $blue-dim, 0 2px 8px rgba(59, 130, 246, 0.15);
+    box-shadow:
+      0 0 0 2px $blue-dim,
+      0 2px 8px rgba(59, 130, 246, 0.15);
 
     &:hover {
-      box-shadow: 0 0 0 2px $blue-dim, 0 2px 8px rgba(59, 130, 246, 0.15);
+      box-shadow:
+        0 0 0 2px $blue-dim,
+        0 2px 8px rgba(59, 130, 246, 0.15);
     }
   }
 
@@ -466,10 +370,14 @@ $red: #ef4444;
     &.selected {
       border-color: $orange;
       background: rgba(249, 115, 22, 0.1);
-      box-shadow: 0 0 0 2px $orange-dim, 0 2px 8px rgba(249, 115, 22, 0.15);
+      box-shadow:
+        0 0 0 2px $orange-dim,
+        0 2px 8px rgba(249, 115, 22, 0.15);
 
       &:hover {
-        box-shadow: 0 0 0 2px $orange-dim, 0 2px 8px rgba(249, 115, 22, 0.15);
+        box-shadow:
+          0 0 0 2px $orange-dim,
+          0 2px 8px rgba(249, 115, 22, 0.15);
       }
     }
   }
@@ -484,7 +392,9 @@ $red: #ef4444;
     transform: scale(0.97);
     pointer-events: none;
     animation: none;
-    transition: opacity 0.2s ease, transform 0.2s cubic-bezier(0.32, 0.72, 0, 1);
+    transition:
+      opacity 0.2s ease,
+      transform 0.2s cubic-bezier(0.32, 0.72, 0, 1);
   }
 }
 
@@ -504,8 +414,11 @@ $red: #ef4444;
   color: rgba(59, 130, 246, 0.7);
   white-space: nowrap;
   pointer-events: none;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  text-shadow: 0 0 4px rgba(255, 255, 255, 0.8), 0 0 8px rgba(255, 255, 255, 0.5);
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  text-shadow:
+    0 0 4px rgba(255, 255, 255, 0.8),
+    0 0 8px rgba(255, 255, 255, 0.5);
 
   .selected & {
     color: $blue;
@@ -532,11 +445,16 @@ $red: #ef4444;
   overflow: hidden;
   text-overflow: ellipsis;
   pointer-events: none;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  text-shadow: 0 0 4px rgba(255, 255, 255, 0.9), 0 0 8px rgba(255, 255, 255, 0.6);
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  text-shadow:
+    0 0 4px rgba(255, 255, 255, 0.9),
+    0 0 8px rgba(255, 255, 255, 0.6);
   opacity: 0;
   transform: translateY(-2px);
-  transition: opacity 0.2s ease, transform 0.2s ease;
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
 
   &.annotationVisible {
     opacity: 1;
@@ -556,11 +474,16 @@ $red: #ef4444;
   overflow: hidden;
   text-overflow: ellipsis;
   pointer-events: none;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
-  text-shadow: 0 0 4px rgba(255, 255, 255, 0.9), 0 0 8px rgba(255, 255, 255, 0.6);
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  text-shadow:
+    0 0 4px rgba(255, 255, 255, 0.9),
+    0 0 8px rgba(255, 255, 255, 0.6);
   opacity: 0;
   transform: translateY(-2px);
-  transition: opacity 0.2s ease, transform 0.2s ease;
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
 
   &.annotationVisible {
     opacity: 1;
@@ -580,12 +503,16 @@ $red: #ef4444;
   border: 1.5px solid $blue;
   border-radius: 2px;
   z-index: 12;
-  box-shadow: 0 0 0 0.5px rgba(0, 0, 0, 0.1), 0 1px 2px rgba(0, 0, 0, 0.12);
+  box-shadow:
+    0 0 0 0.5px rgba(0, 0, 0, 0.1),
+    0 1px 2px rgba(0, 0, 0, 0.12);
   opacity: 0;
   transform: scale(0.3);
   pointer-events: none;
   will-change: opacity, transform;
-  transition: opacity 0.2s ease-out, transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
+  transition:
+    opacity 0.2s ease-out,
+    transform 0.25s cubic-bezier(0.34, 1.56, 0.64, 1);
 
   .placement:hover &,
   .sectionOutline:hover &,
@@ -608,13 +535,35 @@ $red: #ef4444;
   }
 }
 
-.handleNw { top: -4px; left: -4px; cursor: nw-resize; }
-.handleNe { top: -4px; right: -4px; cursor: ne-resize; }
-.handleSe { bottom: -4px; right: -4px; cursor: se-resize; }
-.handleSw { bottom: -4px; left: -4px; cursor: sw-resize; }
+.handleNw {
+  top: -4px;
+  left: -4px;
+  cursor: nw-resize;
+}
+.handleNe {
+  top: -4px;
+  right: -4px;
+  cursor: ne-resize;
+}
+.handleSe {
+  bottom: -4px;
+  right: -4px;
+  cursor: se-resize;
+}
+.handleSw {
+  bottom: -4px;
+  left: -4px;
+  cursor: sw-resize;
+}
 
 // Hide midpoint dot handles (replaced by edge bars)
-.handleN, .handleE, .handleS, .handleW { opacity: 0 !important; pointer-events: none !important; }
+.handleN,
+.handleE,
+.handleS,
+.handleW {
+  opacity: 0 !important;
+  pointer-events: none !important;
+}
 
 // =============================================================================
 // Edge Resize Bars (wide hit areas + arrow indicators)
@@ -638,7 +587,9 @@ $red: #ef4444;
       background: $orange;
     }
     opacity: 0;
-    transition: opacity 0.1s ease, transform 0.1s ease;
+    transition:
+      opacity 0.1s ease,
+      transform 0.1s ease;
     transform: scale(0.8);
   }
 
@@ -662,7 +613,8 @@ $red: #ef4444;
 }
 
 // Horizontal edges (top/bottom) — full width, 12px tall
-.edgeN, .edgeS {
+.edgeN,
+.edgeS {
   left: 12px;
   right: 12px;
   height: 12px;
@@ -674,11 +626,17 @@ $red: #ef4444;
   }
 }
 
-.edgeN { top: -6px; }
-.edgeS { bottom: -6px; cursor: s-resize; }
+.edgeN {
+  top: -6px;
+}
+.edgeS {
+  bottom: -6px;
+  cursor: s-resize;
+}
 
 // Vertical edges (left/right) — full height, 12px wide
-.edgeE, .edgeW {
+.edgeE,
+.edgeW {
   top: 12px;
   bottom: 12px;
   width: 12px;
@@ -690,8 +648,13 @@ $red: #ef4444;
   }
 }
 
-.edgeE { right: -6px; }
-.edgeW { left: -6px; cursor: w-resize; }
+.edgeE {
+  right: -6px;
+}
+.edgeW {
+  left: -6px;
+  cursor: w-resize;
+}
 
 // =============================================================================
 // Delete Button
@@ -720,7 +683,13 @@ $red: #ef4444;
   opacity: 0;
   transform: scale(0.8);
   will-change: opacity, transform;
-  transition: opacity 0.2s ease-out, transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1), background 0.12s ease, color 0.12s ease, border-color 0.12s ease, box-shadow 0.12s ease;
+  transition:
+    opacity 0.2s ease-out,
+    transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1),
+    background 0.12s ease,
+    color 0.12s ease,
+    border-color 0.12s ease,
+    box-shadow 0.12s ease;
 
   .placement:hover &,
   .selected &,
@@ -797,7 +766,8 @@ $red: #ef4444;
   border-radius: 4px;
   white-space: nowrap;
   font-weight: 500;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   box-shadow: 0 2px 6px rgba(0, 0, 0, 0.2);
 }
 
@@ -830,11 +800,15 @@ $red: #ef4444;
   font-size: 9px;
   font-weight: 600;
   color: $blue;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   box-shadow: 0 4px 16px rgba(59, 130, 246, 0.15);
-  transition: width 0.08s ease, height 0.08s ease, opacity 0.08s ease;
+  transition:
+    width 0.08s ease,
+    height 0.08s ease,
+    opacity 0.08s ease;
 }
 
 .dragPreviewWireframe {
@@ -862,13 +836,13 @@ $red: #ef4444;
     0 1px 8px rgba(0, 0, 0, 0.25),
     0 0 0 1px rgba(0, 0, 0, 0.04);
   z-index: 100001;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   cursor: default;
 
   // Initial state (before enter transition triggers)
   opacity: 0;
   filter: blur(5px);
-
 
   // Child element transitions (match settings panel)
   .paletteItem,
@@ -1058,12 +1032,32 @@ $red: #ef4444;
     mask-image: linear-gradient(to bottom, transparent 0, black 32px);
   }
   &.fadeBottom {
-    -webkit-mask-image: linear-gradient(to bottom, black calc(100% - 32px), transparent 100%);
-    mask-image: linear-gradient(to bottom, black calc(100% - 32px), transparent 100%);
+    -webkit-mask-image: linear-gradient(
+      to bottom,
+      black calc(100% - 32px),
+      transparent 100%
+    );
+    mask-image: linear-gradient(
+      to bottom,
+      black calc(100% - 32px),
+      transparent 100%
+    );
   }
   &.fadeTop.fadeBottom {
-    -webkit-mask-image: linear-gradient(to bottom, transparent 0, black 32px, black calc(100% - 32px), transparent 100%);
-    mask-image: linear-gradient(to bottom, transparent 0, black 32px, black calc(100% - 32px), transparent 100%);
+    -webkit-mask-image: linear-gradient(
+      to bottom,
+      transparent 0,
+      black 32px,
+      black calc(100% - 32px),
+      transparent 100%
+    );
+    mask-image: linear-gradient(
+      to bottom,
+      transparent 0,
+      black 32px,
+      black calc(100% - 32px),
+      transparent 100%
+    );
   }
 
   &::-webkit-scrollbar {
@@ -1098,7 +1092,9 @@ $red: #ef4444;
 .paletteFooterInnerContent {
   opacity: 1;
   transform: translateY(0);
-  transition: opacity 0.15s ease, transform 0.15s ease;
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
 
   .footerHidden & {
     opacity: 0;
@@ -1167,7 +1163,6 @@ $red: #ef4444;
   gap: 0.75rem;
 }
 
-
 // Rolling count number
 .rollingWrap {
   display: inline-block;
@@ -1183,28 +1178,59 @@ $red: #ef4444;
   top: 0;
 }
 
-.exitUp { animation: numExitUp 0.25s cubic-bezier(0.32, 0.72, 0, 1) forwards; }
-.enterUp { animation: numEnterUp 0.25s cubic-bezier(0.32, 0.72, 0, 1) forwards; }
-.exitDown { animation: numExitDown 0.25s cubic-bezier(0.32, 0.72, 0, 1) forwards; }
-.enterDown { animation: numEnterDown 0.25s cubic-bezier(0.32, 0.72, 0, 1) forwards; }
+.exitUp {
+  animation: numExitUp 0.25s cubic-bezier(0.32, 0.72, 0, 1) forwards;
+}
+.enterUp {
+  animation: numEnterUp 0.25s cubic-bezier(0.32, 0.72, 0, 1) forwards;
+}
+.exitDown {
+  animation: numExitDown 0.25s cubic-bezier(0.32, 0.72, 0, 1) forwards;
+}
+.enterDown {
+  animation: numEnterDown 0.25s cubic-bezier(0.32, 0.72, 0, 1) forwards;
+}
 
 @keyframes numExitUp {
-  from { transform: translateY(0); opacity: 1; }
-  to { transform: translateY(-110%); opacity: 0; }
+  from {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(-110%);
+    opacity: 0;
+  }
 }
 @keyframes numEnterUp {
-  from { transform: translateY(110%); opacity: 0; }
-  to { transform: translateY(0); opacity: 1; }
+  from {
+    transform: translateY(110%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
 }
 @keyframes numExitDown {
-  from { transform: translateY(0); opacity: 1; }
-  to { transform: translateY(110%); opacity: 0; }
+  from {
+    transform: translateY(0);
+    opacity: 1;
+  }
+  to {
+    transform: translateY(110%);
+    opacity: 0;
+  }
 }
 @keyframes numEnterDown {
-  from { transform: translateY(-110%); opacity: 0; }
-  to { transform: translateY(0); opacity: 1; }
+  from {
+    transform: translateY(-110%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
 }
-
 
 // =============================================================================
 // Rearrange Overlay
@@ -1247,21 +1273,31 @@ $red: #ef4444;
   &:active {
     cursor: grabbing;
   }
-  transition: box-shadow 0.15s, border-color 0.3s, background-color 0.3s, border-style 0s;
+  transition:
+    box-shadow 0.15s,
+    border-color 0.3s,
+    background-color 0.3s,
+    border-style 0s;
   user-select: none;
   pointer-events: auto;
   animation: sectionEnter 0.2s ease;
 
   &:hover {
-    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.1), 0 4px 12px rgba(0, 0, 0, 0.15);
+    box-shadow:
+      0 0 0 1px rgba(255, 255, 255, 0.1),
+      0 4px 12px rgba(0, 0, 0, 0.15);
   }
 
   &.selected {
     border-style: solid;
-    box-shadow: 0 0 0 2px $blue-dim, 0 2px 8px rgba(59, 130, 246, 0.15);
+    box-shadow:
+      0 0 0 2px $blue-dim,
+      0 2px 8px rgba(59, 130, 246, 0.15);
 
     &:hover {
-      box-shadow: 0 0 0 2px $blue-dim, 0 2px 8px rgba(59, 130, 246, 0.15);
+      box-shadow:
+        0 0 0 2px $blue-dim,
+        0 2px 8px rgba(59, 130, 246, 0.15);
     }
   }
 
@@ -1301,7 +1337,9 @@ $red: #ef4444;
     transform: scale(0.97);
     pointer-events: none;
     animation: none;
-    transition: opacity 0.2s ease, transform 0.2s cubic-bezier(0.32, 0.72, 0, 1);
+    transition:
+      opacity 0.2s ease,
+      transform 0.2s cubic-bezier(0.32, 0.72, 0, 1);
   }
 }
 
@@ -1316,7 +1354,8 @@ $red: #ef4444;
   border-radius: 4px;
   white-space: nowrap;
   pointer-events: none;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
   max-width: calc(100% - 8px);
   overflow: hidden;
@@ -1335,18 +1374,23 @@ $red: #ef4444;
   border-radius: 4px;
   white-space: nowrap;
   pointer-events: none;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
   opacity: 0;
   transform: scale(0.8);
-  transition: opacity 0.15s ease, transform 0.15s ease;
+  transition:
+    opacity 0.15s ease,
+    transform 0.15s ease;
 
   &.badgeVisible {
     opacity: 1;
     transform: scale(1);
-    transition: opacity 0.2s cubic-bezier(0.34, 1.2, 0.64, 1), transform 0.2s cubic-bezier(0.34, 1.2, 0.64, 1);
+    transition:
+      opacity 0.2s cubic-bezier(0.34, 1.2, 0.64, 1),
+      transform 0.2s cubic-bezier(0.34, 1.2, 0.64, 1);
   }
 }
 
@@ -1367,7 +1411,8 @@ $red: #ef4444;
   border-radius: 3px;
   white-space: nowrap;
   pointer-events: none;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
 
   .light & {
     color: rgba(0, 0, 0, 0.5);
@@ -1387,7 +1432,8 @@ $red: #ef4444;
   font-size: 9.5px;
   font-weight: 400;
   color: rgba(0, 0, 0, 0.4);
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   pointer-events: auto;
   animation: overlayFadeIn 0.3s ease;
   line-height: 1.5;
@@ -1438,7 +1484,7 @@ $red: #ef4444;
   }
 
   &::-webkit-slider-thumb:hover {
-    background: darken(#f97316, 8%);
+    background: color.adjust(#f97316, $lightness: -8%);
   }
 
   &::-moz-range-thumb {
@@ -1495,7 +1541,6 @@ $red: #ef4444;
   }
 }
 
-
 // =============================================================================
 // Ghost Outlines (suggested placement)
 // =============================================================================
@@ -1510,7 +1555,10 @@ $red: #ef4444;
   user-select: none;
   pointer-events: auto;
   animation: ghostEnter 0.25s ease;
-  transition: box-shadow 0.15s, border-color 0.3s, opacity 0.25s;
+  transition:
+    box-shadow 0.15s,
+    border-color 0.3s,
+    opacity 0.25s;
 
   &:active {
     cursor: grabbing;
@@ -1518,7 +1566,9 @@ $red: #ef4444;
 
   &:hover {
     opacity: 0.7;
-    box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.1), 0 4px 12px rgba(0, 0, 0, 0.08);
+    box-shadow:
+      0 0 0 1px rgba(59, 130, 246, 0.1),
+      0 4px 12px rgba(0, 0, 0, 0.08);
   }
 
   &.selected {
@@ -1527,7 +1577,9 @@ $red: #ef4444;
     border-width: 2px;
     border-color: $blue;
     background: rgba(59, 130, 246, 0.08);
-    box-shadow: 0 0 0 2px $blue-dim, 0 2px 8px rgba(59, 130, 246, 0.15);
+    box-shadow:
+      0 0 0 2px $blue-dim,
+      0 2px 8px rgba(59, 130, 246, 0.15);
   }
 
   &.exiting {
@@ -1535,7 +1587,9 @@ $red: #ef4444;
     transform: scale(0.97);
     pointer-events: none;
     animation: none;
-    transition: opacity 0.2s ease, transform 0.2s cubic-bezier(0.32, 0.72, 0, 1);
+    transition:
+      opacity 0.2s ease,
+      transform 0.2s cubic-bezier(0.32, 0.72, 0, 1);
   }
 }
 
@@ -1552,15 +1606,22 @@ $red: #ef4444;
   border-radius: 3px;
   white-space: nowrap;
   pointer-events: none;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   letter-spacing: 0.02em;
   line-height: 1.2;
   animation: badgeSlideIn 0.2s ease both;
 }
 
 @keyframes badgeSlideIn {
-  from { opacity: 0; transform: translateY(4px); }
-  to { opacity: 1; transform: translateY(0); }
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .ghostBadgeExtra {
@@ -1569,8 +1630,12 @@ $red: #ef4444;
 }
 
 @keyframes badgeExtraIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 // =============================================================================
@@ -1598,7 +1663,8 @@ $red: #ef4444;
   border-radius: 3px;
   white-space: nowrap;
   pointer-events: none;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   background: rgba(150, 150, 150, 0.08);
 }
 
@@ -1627,13 +1693,23 @@ $red: #ef4444;
 }
 
 @keyframes connectorDraw {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 @keyframes connectorDotIn {
-  from { transform: scale(0); opacity: 0; }
-  to { transform: scale(1); opacity: 1; }
+  from {
+    transform: scale(0);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
 }
 
 .connectorExiting {
@@ -1645,13 +1721,23 @@ $red: #ef4444;
 }
 
 @keyframes connectorOut {
-  from { opacity: 1; }
-  to { opacity: 0; }
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
 }
 
 @keyframes connectorDotOut {
-  from { transform: scale(1); opacity: 1; }
-  to { transform: scale(0); opacity: 0; }
+  from {
+    transform: scale(1);
+    opacity: 1;
+  }
+  to {
+    transform: scale(0);
+    opacity: 0;
+  }
 }
 
 // =============================================================================
@@ -1659,28 +1745,52 @@ $red: #ef4444;
 // =============================================================================
 
 @keyframes placementEnter {
-  from { opacity: 0; transform: scale(0.85); }
-  to { opacity: 1; transform: scale(1); }
+  from {
+    opacity: 0;
+    transform: scale(0.85);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 @keyframes sectionEnter {
-  from { opacity: 0; transform: scale(0.96); }
-  to { opacity: 1; transform: scale(1); }
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
 }
 
 @keyframes highlightFadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 @keyframes overlayFadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 @keyframes ghostEnter {
-  from { opacity: 0; transform: scale(0.96); }
-  to { opacity: 0.6; transform: scale(1); }
+  from {
+    opacity: 0;
+    transform: scale(0.96);
+  }
+  to {
+    opacity: 0.6;
+    transform: scale(1);
+  }
 }
-
-

--- a/package/src/components/design-mode/styles.module.scss
+++ b/package/src/components/design-mode/styles.module.scss
@@ -327,6 +327,7 @@ $red: #ef4444;
     border-color 0.15s,
     opacity 0.15s ease,
     transform 0.15s ease;
+  -webkit-user-select: none;
   user-select: none;
   pointer-events: auto;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
@@ -924,6 +925,7 @@ $red: #ef4444;
     background-color 0.15s ease,
     border-color 0.15s ease;
   border: 1px solid transparent;
+  -webkit-user-select: none;
   user-select: none;
   min-height: 24px;
 
@@ -1242,6 +1244,7 @@ $red: #ef4444;
   z-index: 99995;
   pointer-events: none;
   cursor: default;
+  -webkit-user-select: none;
   user-select: none;
   animation: overlayFadeIn 0.15s ease;
 }
@@ -1278,6 +1281,7 @@ $red: #ef4444;
     border-color 0.3s,
     background-color 0.3s,
     border-style 0s;
+  -webkit-user-select: none;
   user-select: none;
   pointer-events: auto;
   animation: sectionEnter 0.2s ease;
@@ -1453,6 +1457,7 @@ $red: #ef4444;
   color: rgba(0, 0, 0, 0.32);
   letter-spacing: 0.02em;
   white-space: nowrap;
+  -webkit-user-select: none;
   user-select: none;
 }
 
@@ -1552,6 +1557,7 @@ $red: #ef4444;
   background: rgba(59, 130, 246, 0.04);
   cursor: grab;
   opacity: 0.5;
+  -webkit-user-select: none;
   user-select: none;
   pointer-events: auto;
   animation: ghostEnter 0.25s ease;
@@ -1648,6 +1654,7 @@ $red: #ef4444;
   border-radius: 4px;
   background: transparent;
   pointer-events: none;
+  -webkit-user-select: none;
   user-select: none;
   animation: sectionEnter 0.2s ease;
 }

--- a/package/src/components/page-toolbar-css/annotation-marker/styles.module.scss
+++ b/package/src/components/page-toolbar-css/annotation-marker/styles.module.scss
@@ -60,6 +60,7 @@
   box-shadow:
     0 2px 6px rgba(0, 0, 0, 0.2),
     inset 0 0 0 1px rgba(0, 0, 0, 0.04);
+  -webkit-user-select: none;
   user-select: none;
   will-change: transform, opacity;
   contain: layout style;

--- a/package/src/components/page-toolbar-css/index.tsx
+++ b/package/src/components/page-toolbar-css/index.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useEffect, useLayoutEffect, useRef } from "react";
 import { createPortal } from "react-dom";
+import { ShadowRoot } from "../shadow-root";
 
 import {
   AnnotationPopupCSS,
@@ -16,15 +17,11 @@ import {
   IconEyeAnimated,
   IconPausePlayAnimated,
   IconXmarkLarge,
-  IconEdit,
-  IconChevronLeft,
-  IconChevronRight,
   IconLayout,
 } from "../icons";
 import { HelpTooltip } from "../help-tooltip";
 import { DesignMode } from "../design-mode";
 import { DesignPalette } from "../design-mode/palette";
-import designStyles from "../design-mode/styles.module.scss";
 import { RearrangeOverlay } from "../design-mode/rearrange";
 import { generateDesignOutput, generateRearrangeOutput } from "../design-mode/output";
 import { detectPageSections } from "../design-mode/section-detection";
@@ -84,11 +81,37 @@ import {
 } from "../../utils/freeze-animations";
 
 import type { Annotation } from "../../types";
-import styles from "./styles.module.scss";
 import { generateOutput } from "../../utils/generate-output";
 import { AnnotationMarker, ExitingMarker, PendingMarker } from "./annotation-marker";
 import { SettingsPanel } from "./settings-panel";
 
+import { css as resetCss } from "../reset.scss";
+import styles, { css as toolbarCss } from "./styles.module.scss";
+import designStyles, {
+  css as designModeCss,
+} from "../design-mode/styles.module.scss";
+import { css as popupCss } from "../annotation-popup-css/styles.module.scss";
+import { css as checkboxCss } from "../checkbox/styles.module.scss";
+import { css as helpTooltipCss } from "../help-tooltip/styles.module.scss";
+import { css as iconTransitionsCss } from "../icon-transitions.module.scss";
+import { css as annotationMarkerCss } from "./annotation-marker/styles.module.scss";
+import { css as checkboxFieldCss } from "./settings-panel/checkbox-field/styles.module.scss";
+import { css as settingsPanelCss } from "./settings-panel/styles.module.scss";
+import { css as switchCss } from "../switch/styles.module.scss";
+
+const shadowCss = [
+  resetCss,
+  toolbarCss,
+  popupCss,
+  checkboxCss,
+  designModeCss,
+  helpTooltipCss,
+  iconTransitionsCss,
+  annotationMarkerCss,
+  checkboxFieldCss,
+  settingsPanelCss,
+  switchCss,
+].join("\n");
 /**
  * Composes element identification with React component detection.
  * This is the boundary where we combine framework-agnostic element ID
@@ -139,7 +162,11 @@ type HoverInfo = {
   reactComponents?: string | null;
 };
 
-export type OutputDetailLevel = "compact" | "standard" | "detailed" | "forensic";
+export type OutputDetailLevel =
+  | "compact"
+  | "standard"
+  | "detailed"
+  | "forensic";
 // ReactComponentMode is now derived from outputDetail when reactEnabled is true
 export type ReactComponentMode = "smart" | "filtered" | "all" | "off";
 type MarkerClickBehavior = "edit" | "delete";
@@ -195,36 +222,28 @@ export const COLOR_OPTIONS = [
   { id: "red",     label: "Red",     srgb: "#FF383C", p3: "color(display-p3 1.00 0.22 0.24)" },
 ];
 
-const injectAgentationColorTokens = () => {
-  if (typeof document === "undefined") return;
-  if (document.getElementById("agentation-color-tokens")) return;
-  const style = document.createElement("style");
-  style.id = "agentation-color-tokens";
-  style.textContent = [
-    ...COLOR_OPTIONS.map(c => `
+const agentationColorTokensCss = [
+  ...COLOR_OPTIONS.map(
+    (c) => `
+    [data-agentation-accent="${c.id}"] {
+      --agentation-color-accent: ${c.srgb};
+    }
+    @supports (color: color(display-p3 0 0 0)) {
       [data-agentation-accent="${c.id}"] {
-        --agentation-color-accent: ${c.srgb};
+        --agentation-color-accent: ${c.p3};
       }
-
-      @supports (color: color(display-p3 0 0 0)) {
-        [data-agentation-accent="${c.id}"] {
-          --agentation-color-accent: ${c.p3};
-        }
-      }
-    `),
-    `:root {
-      ${COLOR_OPTIONS.map(c => `--agentation-color-${c.id}: ${c.srgb};`).join("\n")}
-    }`,
-    `@supports (color: color(display-p3 0 0 0)) {
-      :root {
-        ${COLOR_OPTIONS.map(c => `--agentation-color-${c.id}: ${c.p3};`).join("\n")}
-      }
-    }`,
-  ].join("");
-  document.head.appendChild(style);
-}
-
-injectAgentationColorTokens();
+    }
+  `,
+  ),
+  `:host {
+    ${COLOR_OPTIONS.map((c) => `--agentation-color-${c.id}: ${c.srgb};`).join("\n")}
+  }`,
+  `@supports (color: color(display-p3 0 0 0)) {
+    :host {
+      ${COLOR_OPTIONS.map((c) => `--agentation-color-${c.id}: ${c.p3};`).join("\n")}
+    }
+  }`,
+].join("");
 
 // =============================================================================
 // Utils
@@ -548,20 +567,20 @@ export function PageFeedbackToolbarCSS({
     };
   }, []);
 
-const [settings, setSettings] = useState<ToolbarSettings>(() => {
-  try {
+  const [settings, setSettings] = useState<ToolbarSettings>(() => {
+    try {
     const saved = JSON.parse(localStorage.getItem("feedback-toolbar-settings") ?? "");
-    return {
-      ...DEFAULT_SETTINGS,
-      ...saved,
+      return {
+        ...DEFAULT_SETTINGS,
+        ...saved,
       annotationColorId: COLOR_OPTIONS.find(c => c.id === saved.annotationColorId)
-        ? saved.annotationColorId
-        : DEFAULT_SETTINGS.annotationColorId,
-    };
-  } catch {
-    return DEFAULT_SETTINGS;
-  }
-});
+          ? saved.annotationColorId
+          : DEFAULT_SETTINGS.annotationColorId,
+      };
+    } catch {
+      return DEFAULT_SETTINGS;
+    }
+  });
   const [isDarkMode, setIsDarkMode] = useState(true);
   const [showEntranceAnimation, setShowEntranceAnimation] = useState(false);
 
@@ -1803,20 +1822,13 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
       "mark", "small", "sub", "sup", "[contenteditable]"
     ].join(", ");
 
-    const notAgentationSelector = `:not([data-agentation-root]):not([data-agentation-root] *)`;
-
     const style = document.createElement("style");
     style.id = "feedback-cursor-styles";
     // Text elements get text cursor (higher specificity with body prefix)
     // Everything else gets crosshair
     style.textContent = `
-      body ${notAgentationSelector} {
-        cursor: crosshair !important;
-      }
-
-      body :is(${textElementsSelector})${notAgentationSelector} {
-        cursor: text !important;
-      }
+      body { cursor: crosshair !important; }
+      body :is(${textElementsSelector}) { cursor: text !important; }
     `;
     document.head.appendChild(style);
 
@@ -2754,60 +2766,60 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
   // Handle marker hover - finds element(s) for live position tracking
   const handleMarkerHover = useCallback(
     (annotation: Annotation | null) => {
-      if (!annotation) {
-        setHoveredMarkerId(null);
-        setHoveredTargetElement(null);
-        setHoveredTargetElements([]);
-        return;
-      }
+    if (!annotation) {
+      setHoveredMarkerId(null);
+      setHoveredTargetElement(null);
+      setHoveredTargetElements([]);
+      return;
+    }
 
-      setHoveredMarkerId(annotation.id);
+    setHoveredMarkerId(annotation.id);
 
-      // Find elements at the annotation's position(s) for live tracking
-      if (annotation.elementBoundingBoxes?.length) {
-        // Cmd+shift+click: find element at each bounding box center
-        const elements: HTMLElement[] = [];
-        for (const bb of annotation.elementBoundingBoxes) {
-          const centerX = bb.x + bb.width / 2;
-          const centerY = bb.y + bb.height / 2 - window.scrollY;
-          // Use elementsFromPoint to look through the marker if it's covering
-          const allEls = document.elementsFromPoint(centerX, centerY);
-          const el = allEls.find(
-            (e) => !e.closest('[data-annotation-marker]') && !e.closest('[data-agentation-root]'),
-          ) as HTMLElement | undefined;
-          if (el) elements.push(el);
-        }
-        setHoveredTargetElements(elements);
-        setHoveredTargetElement(null);
-      } else if (annotation.boundingBox) {
-        // Single element
-        const bb = annotation.boundingBox;
+    // Find elements at the annotation's position(s) for live tracking
+    if (annotation.elementBoundingBoxes?.length) {
+      // Cmd+shift+click: find element at each bounding box center
+      const elements: HTMLElement[] = [];
+      for (const bb of annotation.elementBoundingBoxes) {
         const centerX = bb.x + bb.width / 2;
-        const centerY = annotation.isFixed
-          ? bb.y + bb.height / 2
-          : bb.y + bb.height / 2 - window.scrollY;
-        const el = deepElementFromPoint(centerX, centerY);
+        const centerY = bb.y + bb.height / 2 - window.scrollY;
+        // Use elementsFromPoint to look through the marker if it's covering
+        const allEls = document.elementsFromPoint(centerX, centerY);
+        const el = allEls.find(
+            (e) => !e.closest('[data-annotation-marker]') && !e.closest('[data-agentation-root]'),
+        ) as HTMLElement | undefined;
+        if (el) elements.push(el);
+      }
+      setHoveredTargetElements(elements);
+      setHoveredTargetElement(null);
+    } else if (annotation.boundingBox) {
+      // Single element
+      const bb = annotation.boundingBox;
+      const centerX = bb.x + bb.width / 2;
+      const centerY = annotation.isFixed
+        ? bb.y + bb.height / 2
+        : bb.y + bb.height / 2 - window.scrollY;
+      const el = deepElementFromPoint(centerX, centerY);
 
-        // Validate found element's size roughly matches stored bounding box
-        // (prevents using wrong child element when clicking center of a container)
-        if (el) {
-          const elRect = el.getBoundingClientRect();
-          const widthRatio = elRect.width / bb.width;
-          const heightRatio = elRect.height / bb.height;
-          // If found element is much smaller than stored, it's probably a child - don't use it
-          if (widthRatio < 0.5 || heightRatio < 0.5) {
-            setHoveredTargetElement(null);
-          } else {
-            setHoveredTargetElement(el);
-          }
-        } else {
+      // Validate found element's size roughly matches stored bounding box
+      // (prevents using wrong child element when clicking center of a container)
+      if (el) {
+        const elRect = el.getBoundingClientRect();
+        const widthRatio = elRect.width / bb.width;
+        const heightRatio = elRect.height / bb.height;
+        // If found element is much smaller than stored, it's probably a child - don't use it
+        if (widthRatio < 0.5 || heightRatio < 0.5) {
           setHoveredTargetElement(null);
+        } else {
+          setHoveredTargetElement(el);
         }
-        setHoveredTargetElements([]);
       } else {
         setHoveredTargetElement(null);
-        setHoveredTargetElements([]);
       }
+      setHoveredTargetElements([]);
+    } else {
+      setHoveredTargetElement(null);
+      setHoveredTargetElements([]);
+    }
     },
     [],
   );
@@ -3090,16 +3102,16 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
     // Append design layout section if there are placements (or purpose in wireframe mode)
     if (designPlacements.length > 0 || (wireframeOnly && wireframePurpose)) {
       output += "\n" + generateDesignOutput(designPlacements, {
-        width: window.innerWidth,
-        height: window.innerHeight,
+            width: window.innerWidth,
+            height: window.innerHeight,
       }, { blankCanvas, wireframePurpose: wireframePurpose || undefined }, settings.outputDetail);
     }
 
     // Append rearrange section if sections were reordered
     if (rearrangeState) {
       const rearrangeOutput = generateRearrangeOutput(rearrangeState, settings.outputDetail, {
-        width: window.innerWidth,
-        height: window.innerHeight,
+          width: window.innerWidth,
+          height: window.innerHeight,
       });
       if (rearrangeOutput) {
         output += "\n" + rearrangeOutput;
@@ -3160,16 +3172,16 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
     // Append design layout section if there are placements
     if (designPlacements.length > 0) {
       output += "\n" + generateDesignOutput(designPlacements, {
-        width: window.innerWidth,
-        height: window.innerHeight,
+            width: window.innerWidth,
+            height: window.innerHeight,
       }, { blankCanvas, wireframePurpose: wireframePurpose || undefined }, settings.outputDetail);
     }
 
     // Append rearrange section if sections were reordered
     if (rearrangeState) {
       const rearrangeOutput = generateRearrangeOutput(rearrangeState, settings.outputDetail, {
-        width: window.innerWidth,
-        height: window.innerHeight,
+          width: window.innerWidth,
+          height: window.innerHeight,
       });
       if (rearrangeOutput) {
         output += "\n" + rearrangeOutput;
@@ -3563,1018 +3575,793 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
   };
 
   return createPortal(
-    <div ref={portalWrapperRef} style={{ display: "contents" }} data-agentation-theme={isDarkMode ? "dark" : "light"} data-agentation-accent={settings.annotationColorId} data-agentation-root="">
-      {/* Toolbar */}
-      <div
-        className={`${styles.toolbar}${userClassName ? ` ${userClassName}` : ""}`}
-        data-feedback-toolbar
-        data-agentation-toolbar
-        style={
-          toolbarPosition
-            ? {
-                left: toolbarPosition.x,
-                top: toolbarPosition.y,
-                right: "auto",
-                bottom: "auto",
+    <ShadowRoot ref={portalWrapperRef} host="agentation-toolbar" style={{ display: "contents" }}>
+      <style>{shadowCss}{agentationColorTokensCss}</style>
+      <div style={{ display: "contents" }} data-agentation-theme={isDarkMode ? "dark" : "light"} data-agentation-accent={settings.annotationColorId} data-agentation-root="">
+          {/* Toolbar */}
+          <div
+            className={`${styles.toolbar}${userClassName ? ` ${userClassName}` : ""}`}
+            data-feedback-toolbar
+            data-agentation-toolbar
+            style={
+              toolbarPosition
+                ? {
+                    left: toolbarPosition.x,
+                    top: toolbarPosition.y,
+                    right: "auto",
+                    bottom: "auto",
+                  }
+                : undefined
+            }
+          >
+            {/* Morphing container */}
+            <div
+              className={`${styles.toolbarContainer} ${isActive ? styles.expanded : styles.collapsed} ${showEntranceAnimation ? styles.entrance : ""} ${isToolbarHiding ? styles.hiding : ""} ${!settings.webhooksEnabled && (isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "")) ? styles.serverConnected : ""}`}
+              onClick={
+                !isActive
+                  ? (e) => {
+                      // Don't activate if we just finished dragging
+                      if (justFinishedToolbarDragRef.current) {
+                        justFinishedToolbarDragRef.current = false;
+                        e.preventDefault();
+                        return;
+                      }
+                      setIsActive(true);
+                    }
+                  : undefined
               }
-            : undefined
-        }
-      >
-        {/* Morphing container */}
-        <div
-          className={`${styles.toolbarContainer} ${isActive ? styles.expanded : styles.collapsed} ${showEntranceAnimation ? styles.entrance : ""} ${isToolbarHiding ? styles.hiding : ""} ${!settings.webhooksEnabled && (isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "")) ? styles.serverConnected : ""}`}
-          onClick={
-            !isActive
-              ? (e) => {
-                  // Don't activate if we just finished dragging
-                  if (justFinishedToolbarDragRef.current) {
-                    justFinishedToolbarDragRef.current = false;
-                    e.preventDefault();
-                    return;
-                  }
-                  setIsActive(true);
-                }
-              : undefined
-          }
-          onMouseDown={handleToolbarMouseDown}
-          role={!isActive ? "button" : undefined}
-          tabIndex={!isActive ? 0 : -1}
-          title={!isActive ? "Start feedback mode" : undefined}
-        >
-          {/* Toggle content - visible when collapsed */}
-          <div
-            className={`${styles.toggleContent} ${!isActive ? styles.visible : styles.hidden}`}
-          >
-            <IconListSparkle size={24} />
-            {hasVisibleAnnotations && (
-              <span
-                className={`${styles.badge} ${isActive ? styles.fadeOut : ""} ${showEntranceAnimation ? styles.entrance : ""}`}
-              >
-                {visibleAnnotations.length}
-              </span>
-            )}
-          </div>
-
-          {/* Controls content - visible when expanded */}
-          <div
-            className={`${styles.controlsContent} ${isActive ? styles.visible : styles.hidden} ${
-              toolbarPosition && toolbarPosition.y < 100
-                ? styles.tooltipBelow
-                : ""
-            } ${tooltipsHidden || showSettings ? styles.tooltipsHidden : ""} ${tooltipSessionActive ? styles.tooltipsInSession : ""}`}
-            onMouseEnter={handleControlsMouseEnter}
-            onMouseLeave={handleControlsMouseLeave}
-          >
-            <div
-              className={`${styles.buttonWrapper} ${
-                toolbarPosition && toolbarPosition.x < 120
-                  ? styles.buttonWrapperAlignLeft
-                  : ""
-              }`}
+              onMouseDown={handleToolbarMouseDown}
+              role={!isActive ? "button" : undefined}
+              tabIndex={!isActive ? 0 : -1}
+              title={!isActive ? "Start feedback mode" : undefined}
             >
-              <button
-                className={styles.controlButton}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  hideTooltipsUntilMouseLeave();
-                  toggleFreeze();
-                }}
-                data-active={isFrozen}
+              {/* Toggle content - visible when collapsed */}
+              <div
+                className={`${styles.toggleContent} ${!isActive ? styles.visible : styles.hidden}`}
               >
-                <IconPausePlayAnimated size={24} isPaused={isFrozen} />
-              </button>
-              <span className={styles.buttonTooltip}>
-                {isFrozen ? "Resume animations" : "Pause animations"}
-                <span className={styles.shortcut}>P</span>
-              </span>
-            </div>
-
-            {/* Draw mode disabled for now
-            <div className={styles.buttonWrapper}>
-              <button
-                className={`${styles.controlButton} ${!isDarkMode ? styles.light : ""}`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  hideTooltipsUntilMouseLeave();
-                  if (isDesignMode) closeDesignMode();
-                  setIsDrawMode(prev => !prev);
-                }}
-                data-active={isDrawMode}
-              >
-                <IconPencil size={24} />
-              </button>
-              <span className={styles.buttonTooltip}>
-                {isDrawMode ? "Exit draw mode" : "Draw mode"}
-                <span className={styles.shortcut}>D</span>
-              </span>
-            </div>
-            */}
-
-            <div className={styles.buttonWrapper}>
-              <button
-                className={`${styles.controlButton} ${!isDarkMode ? styles.light : ""}`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  hideTooltipsUntilMouseLeave();
-                  if (isDrawMode) setIsDrawMode(false);
-                  if (showSettings) setShowSettings(false);
-                  if (pendingAnnotation) cancelAnnotation();
-                  if (isDesignMode) {
-                    closeDesignMode();
-                  } else {
-                    setIsDesignMode(true);
-                  }
-                }}
-                data-active={isDesignMode}
-                style={isDesignMode && blankCanvas ? { color: '#f97316', background: 'rgba(249, 115, 22, 0.25)' } : undefined}
-              >
-                <IconLayout size={21} />
-              </button>
-              <span className={styles.buttonTooltip}>
-                {isDesignMode ? "Exit layout mode" : "Layout mode"}
-                <span className={styles.shortcut}>L</span>
-              </span>
-            </div>
-
-            <div className={styles.buttonWrapper}>
-              <button
-                className={styles.controlButton}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  hideTooltipsUntilMouseLeave();
-                  setShowMarkers(!showMarkers);
-                }}
-                disabled={!hasAnnotations || isDesignMode}
-              >
-                <IconEyeAnimated size={24} isOpen={showMarkers} />
-              </button>
-              <span className={styles.buttonTooltip}>
-                {showMarkers ? "Hide markers" : "Show markers"}
-                <span className={styles.shortcut}>H</span>
-              </span>
-            </div>
-
-            <div className={styles.buttonWrapper}>
-              <button
-                className={`${styles.controlButton} ${copied ? styles.statusShowing : ""}`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  hideTooltipsUntilMouseLeave();
-                  copyOutput();
-                }}
-                disabled={isDesignMode && blankCanvas
-                  ? designPlacements.length === 0 && !(rearrangeState?.sections?.length)
-                  : !hasAnnotations && drawStrokes.length === 0 && designPlacements.length === 0 && !(rearrangeState?.sections?.length)}
-                data-active={copied}
-              >
-                <IconCopyAnimated size={24} copied={copied} tint={isDesignMode && blankCanvas && (designPlacements.length > 0 || !!(rearrangeState?.sections?.length)) ? "#f97316" : undefined} />
-              </button>
-              <span className={styles.buttonTooltip}>
-                {isDesignMode && blankCanvas ? "Copy layout" : "Copy feedback"}
-                <span className={styles.shortcut}>C</span>
-              </span>
-            </div>
-
-            {/* Send button - only visible when webhook URL is available AND auto-send is off */}
-            <div
-              className={`${styles.buttonWrapper} ${styles.sendButtonWrapper} ${isActive && !settings.webhooksEnabled && (isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "")) ? styles.sendButtonVisible : ""}`}
-            >
-              <button
-                className={`${styles.controlButton} ${sendState === "sent" || sendState === "failed" ? styles.statusShowing : ""}`}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  hideTooltipsUntilMouseLeave();
-                  sendToWebhook();
-                }}
-                disabled={
-                  !hasAnnotations ||
-                  (!isValidUrl(settings.webhookUrl) &&
-                    !isValidUrl(webhookUrl || "")) ||
-                  sendState === "sending"
-                }
-                data-no-hover={sendState === "sent" || sendState === "failed"}
-                tabIndex={
-                  isValidUrl(settings.webhookUrl) ||
-                  isValidUrl(webhookUrl || "")
-                    ? 0
-                    : -1
-                }
-              >
-                <IconSendArrow size={24} state={sendState} />
-                {hasAnnotations && sendState === "idle" && (
+                <IconListSparkle size={24} />
+                {hasVisibleAnnotations && (
                   <span
-                    className={styles.buttonBadge}
+                    className={`${styles.badge} ${isActive ? styles.fadeOut : ""} ${showEntranceAnimation ? styles.entrance : ""}`}
                   >
-                    {annotations.length}
+                    {visibleAnnotations.length}
                   </span>
                 )}
-              </button>
-              <span className={styles.buttonTooltip}>
-                Send Annotations
-                <span className={styles.shortcut}>S</span>
-              </span>
-            </div>
+              </div>
 
-            <div className={styles.buttonWrapper}>
-              <button
-                className={styles.controlButton}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  hideTooltipsUntilMouseLeave();
-                  clearAll();
-                }}
-                disabled={!hasAnnotations && drawStrokes.length === 0 && designPlacements.length === 0 && !(rearrangeState?.sections?.length)}
-                data-danger
+              {/* Controls content - visible when expanded */}
+              <div
+                className={`${styles.controlsContent} ${isActive ? styles.visible : styles.hidden} ${
+                  toolbarPosition && toolbarPosition.y < 100
+                    ? styles.tooltipBelow
+                    : ""
+                } ${tooltipsHidden || showSettings ? styles.tooltipsHidden : ""} ${tooltipSessionActive ? styles.tooltipsInSession : ""}`}
+                onMouseEnter={handleControlsMouseEnter}
+                onMouseLeave={handleControlsMouseLeave}
               >
-                <IconTrashAlt size={24} />
-              </button>
-              <span className={styles.buttonTooltip}>
-                Clear all
-                <span className={styles.shortcut}>X</span>
-              </span>
-            </div>
+                <div
+                  className={`${styles.buttonWrapper} ${
+                    toolbarPosition && toolbarPosition.x < 120
+                      ? styles.buttonWrapperAlignLeft
+                      : ""
+                  }`}
+                >
+                  <button
+                    className={styles.controlButton}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      hideTooltipsUntilMouseLeave();
+                      toggleFreeze();
+                    }}
+                    data-active={isFrozen}
+                  >
+                    <IconPausePlayAnimated size={24} isPaused={isFrozen} />
+                  </button>
+                  <span className={styles.buttonTooltip}>
+                    {isFrozen ? "Resume animations" : "Pause animations"}
+                    <span className={styles.shortcut}>P</span>
+                  </span>
+                </div>
 
-            <div className={styles.buttonWrapper}>
-              <button
-                className={styles.controlButton}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  hideTooltipsUntilMouseLeave();
-                  if (isDesignMode) closeDesignMode();
-                  setShowSettings(!showSettings);
+                {/* Draw mode disabled for now
+                <div className={styles.buttonWrapper}>
+                  <button
+                    className={`${styles.controlButton} ${!isDarkMode ? styles.light : ""}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      hideTooltipsUntilMouseLeave();
+                      if (isDesignMode) closeDesignMode();
+                      setIsDrawMode(prev => !prev);
+                    }}
+                    data-active={isDrawMode}
+                  >
+                    <IconPencil size={24} />
+                  </button>
+                  <span className={styles.buttonTooltip}>
+                    {isDrawMode ? "Exit draw mode" : "Draw mode"}
+                    <span className={styles.shortcut}>D</span>
+                  </span>
+                </div>
+                */}
+
+                <div className={styles.buttonWrapper}>
+                  <button
+                    className={`${styles.controlButton} ${!isDarkMode ? styles.light : ""}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      hideTooltipsUntilMouseLeave();
+                      if (isDrawMode) setIsDrawMode(false);
+                      if (showSettings) setShowSettings(false);
+                      if (pendingAnnotation) cancelAnnotation();
+                      if (isDesignMode) {
+                        closeDesignMode();
+                      } else {
+                        setIsDesignMode(true);
+                      }
+                    }}
+                    data-active={isDesignMode}
+                  style={isDesignMode && blankCanvas ? { color: '#f97316', background: 'rgba(249, 115, 22, 0.25)' } : undefined}
+                  >
+                    <IconLayout size={21} />
+                  </button>
+                  <span className={styles.buttonTooltip}>
+                    {isDesignMode ? "Exit layout mode" : "Layout mode"}
+                    <span className={styles.shortcut}>L</span>
+                  </span>
+                </div>
+
+                <div className={styles.buttonWrapper}>
+                  <button
+                    className={styles.controlButton}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      hideTooltipsUntilMouseLeave();
+                      setShowMarkers(!showMarkers);
+                    }}
+                    disabled={!hasAnnotations || isDesignMode}
+                  >
+                    <IconEyeAnimated size={24} isOpen={showMarkers} />
+                  </button>
+                  <span className={styles.buttonTooltip}>
+                    {showMarkers ? "Hide markers" : "Show markers"}
+                    <span className={styles.shortcut}>H</span>
+                  </span>
+                </div>
+
+                <div className={styles.buttonWrapper}>
+                  <button
+                    className={`${styles.controlButton} ${copied ? styles.statusShowing : ""}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      hideTooltipsUntilMouseLeave();
+                      copyOutput();
+                    }}
+                  disabled={isDesignMode && blankCanvas
+                    ? designPlacements.length === 0 && !(rearrangeState?.sections?.length)
+                    : !hasAnnotations && drawStrokes.length === 0 && designPlacements.length === 0 && !(rearrangeState?.sections?.length)}
+                    data-active={copied}
+                  >
+                  <IconCopyAnimated size={24} copied={copied} tint={isDesignMode && blankCanvas && (designPlacements.length > 0 || !!(rearrangeState?.sections?.length)) ? "#f97316" : undefined} />
+                  </button>
+                  <span className={styles.buttonTooltip}>
+                  {isDesignMode && blankCanvas ? "Copy layout" : "Copy feedback"}
+                    <span className={styles.shortcut}>C</span>
+                  </span>
+                </div>
+
+                {/* Send button - only visible when webhook URL is available AND auto-send is off */}
+                <div
+                  className={`${styles.buttonWrapper} ${styles.sendButtonWrapper} ${isActive && !settings.webhooksEnabled && (isValidUrl(settings.webhookUrl) || isValidUrl(webhookUrl || "")) ? styles.sendButtonVisible : ""}`}
+                >
+                  <button
+                    className={`${styles.controlButton} ${sendState === "sent" || sendState === "failed" ? styles.statusShowing : ""}`}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      hideTooltipsUntilMouseLeave();
+                      sendToWebhook();
+                    }}
+                    disabled={
+                      !hasAnnotations ||
+                      (!isValidUrl(settings.webhookUrl) &&
+                        !isValidUrl(webhookUrl || "")) ||
+                      sendState === "sending"
+                    }
+                    data-no-hover={sendState === "sent" || sendState === "failed"}
+                    tabIndex={
+                      isValidUrl(settings.webhookUrl) ||
+                      isValidUrl(webhookUrl || "")
+                        ? 0
+                        : -1
+                    }
+                  >
+                    <IconSendArrow size={24} state={sendState} />
+                    {hasAnnotations && sendState === "idle" && (
+                    <span
+                      className={styles.buttonBadge}
+                    >
+                        {annotations.length}
+                      </span>
+                    )}
+                  </button>
+                  <span className={styles.buttonTooltip}>
+                    Send Annotations
+                    <span className={styles.shortcut}>S</span>
+                  </span>
+                </div>
+
+                <div className={styles.buttonWrapper}>
+                  <button
+                    className={styles.controlButton}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      hideTooltipsUntilMouseLeave();
+                      clearAll();
+                    }}
+                  disabled={!hasAnnotations && drawStrokes.length === 0 && designPlacements.length === 0 && !(rearrangeState?.sections?.length)}
+                    data-danger
+                  >
+                    <IconTrashAlt size={24} />
+                  </button>
+                  <span className={styles.buttonTooltip}>
+                    Clear all
+                    <span className={styles.shortcut}>X</span>
+                  </span>
+                </div>
+
+                <div className={styles.buttonWrapper}>
+                  <button
+                    className={styles.controlButton}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      hideTooltipsUntilMouseLeave();
+                      if (isDesignMode) closeDesignMode();
+                      setShowSettings(!showSettings);
+                    }}
+                  >
+                    <IconGear size={24} />
+                  </button>
+                  {endpoint && connectionStatus !== "disconnected" && (
+                    <span
+                      className={`${styles.mcpIndicator} ${styles[connectionStatus]} ${showSettings ? styles.hidden : ""}`}
+                      title={
+                        connectionStatus === "connected"
+                          ? "MCP Connected"
+                          : "MCP Connecting..."
+                      }
+                    />
+                  )}
+                  <span className={styles.buttonTooltip}>Settings</span>
+                </div>
+
+              <div
+                className={styles.divider}
+              />
+
+                <div
+                  className={`${styles.buttonWrapper} ${
+                    toolbarPosition &&
+                    typeof window !== "undefined" &&
+                    toolbarPosition.x > window.innerWidth - 120
+                      ? styles.buttonWrapperAlignRight
+                      : ""
+                  }`}
+                >
+                  <button
+                    className={styles.controlButton}
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      hideTooltipsUntilMouseLeave();
+                      deactivate();
+                    }}
+                  >
+                    <IconXmarkLarge size={24} />
+                  </button>
+                  <span className={styles.buttonTooltip}>
+                    Exit
+                    <span className={styles.shortcut}>Esc</span>
+                  </span>
+                </div>
+              </div>
+
+              {/* Layout Mode Palette */}
+              <DesignPalette
+                visible={isDesignMode && isActive}
+                activeType={activeDesignComponent}
+                onSelect={(type) => {
+                  setActiveDesignComponent(activeDesignComponent === type ? null : type);
                 }}
-              >
-                <IconGear size={24} />
-              </button>
-              {endpoint && connectionStatus !== "disconnected" && (
-                <span
-                  className={`${styles.mcpIndicator} ${styles[connectionStatus]} ${showSettings ? styles.hidden : ""}`}
-                  title={
-                    connectionStatus === "connected"
-                      ? "MCP Connected"
-                      : "MCP Connecting..."
-                  }
-                />
-              )}
-              <span className={styles.buttonTooltip}>Settings</span>
-            </div>
-
-            <div
-              className={styles.divider}
-            />
-
-            <div
-              className={`${styles.buttonWrapper} ${
-                toolbarPosition &&
-                typeof window !== "undefined" &&
-                toolbarPosition.x > window.innerWidth - 120
-                  ? styles.buttonWrapperAlignRight
-                  : ""
-              }`}
-            >
-              <button
-                className={styles.controlButton}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  hideTooltipsUntilMouseLeave();
-                  deactivate();
-                }}
-              >
-                <IconXmarkLarge size={24} />
-              </button>
-              <span className={styles.buttonTooltip}>
-                Exit
-                <span className={styles.shortcut}>Esc</span>
-              </span>
-            </div>
-          </div>
-
-          {/* Layout Mode Palette */}
-            <DesignPalette
-              visible={isDesignMode && isActive}
-              activeType={activeDesignComponent}
-              onSelect={(type) => {
-                setActiveDesignComponent(activeDesignComponent === type ? null : type);
-              }}
-              isDarkMode={isDarkMode}
-              sectionCount={rearrangeState?.sections.length ?? 0}
-              onDetectSections={() => {
-                const sections = detectPageSections();
-                const existing = rearrangeState?.sections ?? [];
-                const existingSelectors = new Set(existing.map(s => s.selector));
-                const newSections = sections.filter(s => !existingSelectors.has(s.selector));
-                const merged = [...existing, ...newSections];
-                const mergedOrder = [...(rearrangeState?.originalOrder ?? []), ...newSections.map(s => s.id)];
-                setRearrangeState({
-                  sections: merged,
-                  originalOrder: mergedOrder,
-                  detectedAt: Date.now(),
-                });
-              }}
-              placementCount={designPlacements.length}
-              onClearPlacements={() => {
-                // Animate placements and rearrange sections out, then clear
-                setDesignClearSignal(n => n + 1);
-                setRearrangeClearSignal(n => n + 1);
-                originalSetTimeout(() => {
+                isDarkMode={isDarkMode}
+                sectionCount={rearrangeState?.sections.length ?? 0}
+                onDetectSections={() => {
+                  const sections = detectPageSections();
+                  const existing = rearrangeState?.sections ?? [];
+                  const existingSelectors = new Set(existing.map(s => s.selector));
+                  const newSections = sections.filter(s => !existingSelectors.has(s.selector));
+                  const merged = [...existing, ...newSections];
+                  const mergedOrder = [...(rearrangeState?.originalOrder ?? []), ...newSections.map(s => s.id)];
                   setRearrangeState({
-                    sections: [],
-                    originalOrder: [],
+                    sections: merged,
+                    originalOrder: mergedOrder,
                     detectedAt: Date.now(),
                   });
-                }, 200);
-              }}
-              blankCanvas={blankCanvas}
-              onBlankCanvasChange={(on) => {
-                const emptyRearrange = { sections: [], originalOrder: [], detectedAt: Date.now() };
-                if (on) {
-                  // Entering wireframe: stash all explore state, restore wireframe state
-                  exploreStashRef.current = { rearrange: rearrangeState, placements: designPlacements };
-                  setRearrangeState(wireframeStashRef.current.rearrange || emptyRearrange);
-                  setDesignPlacements(wireframeStashRef.current.placements);
-                  setActiveDesignComponent(null);
-                } else {
-                  // Leaving wireframe: stash all wireframe state, restore explore state
-                  wireframeStashRef.current = { rearrange: rearrangeState, placements: designPlacements };
-                  setRearrangeState(exploreStashRef.current.rearrange || emptyRearrange);
-                  setDesignPlacements(exploreStashRef.current.placements);
-                }
-                setBlankCanvas(on);
-              }}
-              wireframePurpose={wireframePurpose}
-              onWireframePurposeChange={setWireframePurpose}
-              Tooltip={HelpTooltip}
-              onDragStart={(type, e) => {
-                e.preventDefault();
-                const def = DEFAULT_SIZES[type];
-                let preview: HTMLDivElement | null = null;
-                let didDrag = false;
-                const startX = e.clientX;
-                const startY = e.clientY;
-
-                // Find toolbar bottom for distance-based scaling
-                const toolbar = (e.target as HTMLElement).closest("[data-feedback-toolbar]");
-                const toolbarTop = toolbar?.getBoundingClientRect().top ?? window.innerHeight;
-
-                const onMove = (ev: MouseEvent) => {
-                  const dx = ev.clientX - startX;
-                  const dy = ev.clientY - startY;
-
-                  if (!didDrag && (Math.abs(dx) > 4 || Math.abs(dy) > 4)) {
-                    didDrag = true;
-                    preview = document.createElement("div");
-                    preview.className = `${designStyles.dragPreview}${blankCanvas ? ` ${designStyles.dragPreviewWireframe}` : ""}`;
-                    document.body.appendChild(preview);
-                  }
-
-                  if (!preview) return;
-
-                  // Scale up as cursor moves away from toolbar
-                  const dist = Math.max(0, toolbarTop - ev.clientY);
-                  const progress = Math.min(1, dist / 180);
-                  const eased = 1 - Math.pow(1 - progress, 2); // ease-out
-
-                  const minW = 28;
-                  const minH = 20;
-                  const maxW = Math.min(140, def.width * 0.18);
-                  const maxH = Math.min(90, def.height * 0.18);
-                  const w = minW + (maxW - minW) * eased;
-                  const h = minH + (maxH - minH) * eased;
-
-                  preview.style.width = `${w}px`;
-                  preview.style.height = `${h}px`;
-                  preview.style.left = `${ev.clientX - w / 2}px`;
-                  preview.style.top = `${ev.clientY - h / 2}px`;
-                  preview.style.opacity = `${0.5 + 0.5 * eased}`;
-                  preview.textContent = eased > 0.25 ? type : "";
-                };
-
-                const onUp = (ev: MouseEvent) => {
-                  window.removeEventListener("mousemove", onMove);
-                  window.removeEventListener("mouseup", onUp);
-                  if (preview) document.body.removeChild(preview);
-
-                  if (didDrag) {
-                    const w = def.width;
-                    const h = def.height;
-                    const scrollY = window.scrollY;
-                    const x = Math.max(0, ev.clientX - w / 2);
-                    const y = Math.max(0, ev.clientY + scrollY - h / 2);
-                    const placement: DesignPlacement = {
-                      id: `dp-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
-                      type,
-                      x,
-                      y,
-                      width: w,
-                      height: h,
-                      scrollY,
-                      timestamp: Date.now(),
-                    };
-                    setDesignPlacements((prev) => [...prev, placement]);
-                    setActiveDesignComponent(null);
-                    // Deselect any previously selected placements
-                    designSelectedIdsRef.current = new Set();
-                    setDesignDeselectSignal(n => n + 1);
-                  }
-                };
-
-                window.addEventListener("mousemove", onMove);
-                window.addEventListener("mouseup", onUp);
-              }}
-            />
-
-          <SettingsPanel
-            settings={settings}
-            onSettingsChange={(patch) => setSettings((s) => ({ ...s, ...patch }))}
-            isDarkMode={isDarkMode}
-            onToggleTheme={toggleTheme}
-            isDevMode={isDevMode}
-            connectionStatus={connectionStatus}
-            endpoint={endpoint}
-            isVisible={showSettingsVisible}
-            toolbarNearBottom={!!toolbarPosition && toolbarPosition.y < 230}
-            settingsPage={settingsPage}
-            onSettingsPageChange={setSettingsPage}
-            onHideToolbar={hideToolbarTemporarily}
-          />
-        </div>
-      </div>
-
-      {/* Blank canvas backdrop — stays mounted so opacity transition works on open/close */}
-      {(isDesignMode || designOverlayExiting) && (
-        <div
-          className={`${designStyles.blankCanvas} ${canvasReady ? designStyles.visible : ""} ${designInteracting ? designStyles.gridActive : ""}`}
-          style={{ '--canvas-opacity': canvasOpacity } as React.CSSProperties}
-          data-feedback-toolbar
-        />
-      )}
-
-      {/* Wireframe hint — bottom-left notice */}
-      {isDesignMode && blankCanvas && canvasReady && (
-        <div className={designStyles.wireframeNotice} data-feedback-toolbar>
-          <div className={designStyles.wireframeOpacityRow}>
-            <span className={designStyles.wireframeOpacityLabel}>Toggle Opacity</span>
-            <input
-              type="range"
-              className={designStyles.wireframeOpacitySlider}
-              min={0}
-              max={1}
-              step={0.01}
-              value={canvasOpacity}
-              onChange={(e) => setCanvasOpacity(Number(e.target.value))}
-            />
-          </div>
-          <div className={designStyles.wireframeNoticeTitleRow}>
-            <span className={designStyles.wireframeNoticeTitle}>Wireframe Mode</span>
-            <span className={designStyles.wireframeNoticeDivider} />
-            <button
-              className={designStyles.wireframeStartOver}
-              onClick={() => {
-                setDesignClearSignal(n => n + 1);
-                setRearrangeState({ sections: [], originalOrder: [], detectedAt: Date.now() });
-                wireframeStashRef.current = { rearrange: null, placements: [] };
-                setWireframePurpose("");
-                clearWireframeState(pathname);
-              }}
-            >
-              Start Over
-            </button>
-          </div>
-          Drag components onto the canvas.<br />Copied output will only include the wireframed layout.
-        </div>
-      )}
-
-      {/* Layout mode overlay — passthrough when no component selected */}
-      {(isDesignMode || designOverlayExiting) && (
-        <DesignMode
-          placements={designPlacements}
-          onChange={setDesignPlacements}
-          activeComponent={designOverlayExiting ? null : activeDesignComponent}
-          onActiveComponentChange={setActiveDesignComponent}
-          isDarkMode={isDarkMode}
-          exiting={designOverlayExiting}
-          onInteractionChange={setDesignInteracting}
-          passthrough={!activeDesignComponent}
-          extraSnapRects={rearrangeState?.sections.map(s => s.currentRect)}
-          deselectSignal={designDeselectSignal}
-          clearSignal={designClearSignal}
-          wireframe={blankCanvas}
-          onSelectionChange={(ids, isShift) => {
-            designSelectedIdsRef.current = ids;
-            if (!isShift) {
-              rearrangeSelectedIdsRef.current = new Set();
-              setRearrangeDeselectSignal(n => n + 1);
-            }
-          }}
-          onDragMove={(dx, dy) => {
-            // Move selected rearrange sections by same delta
-            const selIds = rearrangeSelectedIdsRef.current;
-            if (!selIds.size || !rearrangeState) return;
-            // Cache start positions on first move
-            if (!crossDragStartRef.current) {
-              crossDragStartRef.current = new Map();
-              for (const s of rearrangeState.sections) {
-                if (selIds.has(s.id)) {
-                  crossDragStartRef.current.set(s.id, { x: s.currentRect.x, y: s.currentRect.y });
-                }
-              }
-            }
-            for (const s of rearrangeState.sections) {
-              if (!selIds.has(s.id)) continue;
-              const start = crossDragStartRef.current.get(s.id);
-              if (!start) continue;
-              const outlineEl = document.querySelector(`[data-rearrange-section="${s.id}"]`) as HTMLElement | null;
-              if (outlineEl) outlineEl.style.transform = `translate(${dx}px, ${dy}px)`;
-            }
-          }}
-          onDragEnd={(dx, dy, committed) => {
-            const selIds = rearrangeSelectedIdsRef.current;
-            const starts = crossDragStartRef.current;
-            crossDragStartRef.current = null;
-            if (!selIds.size || !rearrangeState || !starts) return;
-            // Clear outline transforms
-            for (const id of selIds) {
-              const el = document.querySelector(`[data-rearrange-section="${id}"]`) as HTMLElement | null;
-              if (el) el.style.transform = "";
-            }
-            if (committed) {
-              setRearrangeState(prev => {
-                if (!prev) return prev;
-                return {
-                  ...prev,
-                  sections: prev.sections.map(s => {
-                    const start = starts.get(s.id);
-                    if (!start) return s;
-                    return { ...s, currentRect: { ...s.currentRect, x: Math.max(0, start.x + dx), y: Math.max(0, start.y + dy) } };
-                  }),
-                };
-              });
-            }
-          }}
-        />
-      )}
-
-      {/* Rearrange overlay — always active alongside design overlay */}
-      {(isDesignMode || designOverlayExiting) && rearrangeState && (
-        <RearrangeOverlay
-          rearrangeState={rearrangeState}
-          onChange={setRearrangeState}
-          isDarkMode={isDarkMode}
-          exiting={designOverlayExiting}
-          blankCanvas={blankCanvas}
-          extraSnapRects={designPlacements.map(p => ({ x: p.x, y: p.y, width: p.width, height: p.height }))}
-          clearSignal={rearrangeClearSignal}
-          deselectSignal={rearrangeDeselectSignal}
-          onSelectionChange={(ids, isShift) => {
-            rearrangeSelectedIdsRef.current = ids;
-            if (!isShift) {
-              designSelectedIdsRef.current = new Set();
-              setDesignDeselectSignal(n => n + 1);
-            }
-          }}
-          onDragMove={(dx, dy) => {
-            // Move selected design placements by same delta
-            const selIds = designSelectedIdsRef.current;
-            if (!selIds.size) return;
-            // Cache start positions on first move
-            if (!crossDragStartRef.current) {
-              crossDragStartRef.current = new Map();
-              for (const p of designPlacements) {
-                if (selIds.has(p.id)) {
-                  crossDragStartRef.current.set(p.id, { x: p.x, y: p.y });
-                }
-              }
-            }
-            // Imperatively move placement divs
-            for (const id of selIds) {
-              const el = document.querySelector(`[data-design-placement="${id}"]`) as HTMLElement | null;
-              if (el) el.style.transform = `translate(${dx}px, ${dy}px)`;
-            }
-          }}
-          onDragEnd={(dx, dy, committed) => {
-            const selIds = designSelectedIdsRef.current;
-            const starts = crossDragStartRef.current;
-            crossDragStartRef.current = null;
-            if (!selIds.size || !starts) return;
-            // Clear transforms
-            for (const id of selIds) {
-              const el = document.querySelector(`[data-design-placement="${id}"]`) as HTMLElement | null;
-              if (el) el.style.transform = "";
-            }
-            if (committed) {
-              setDesignPlacements(prev => prev.map(p => {
-                const start = starts.get(p.id);
-                if (!start) return p;
-                return { ...p, x: Math.max(0, start.x + dx), y: Math.max(0, start.y + dy) };
-              }));
-            }
-          }}
-        />
-      )}
-
-      {/* Draw canvas — outside overlay so it can fade on toolbar close */}
-      <canvas
-        ref={drawCanvasRef}
-        className={`${styles.drawCanvas} ${isDrawMode ? styles.active : ""}`}
-        style={{ opacity: shouldShowMarkers ? 1 : 0, transition: "opacity 0.15s ease" }}
-        data-feedback-toolbar
-      />
-
-      {/* Markers layer - normal scrolling markers */}
-      <div className={styles.markersLayer} data-feedback-toolbar>
-        {markersVisible &&
-          visibleAnnotations
-            .filter((a) => !a.isFixed)
-            .map((annotation, layerIndex, arr) => (
-              <AnnotationMarker
-                key={annotation.id}
-                annotation={annotation}
-                globalIndex={visibleAnnotations.findIndex((a) => a.id === annotation.id)}
-                layerIndex={layerIndex}
-                layerSize={arr.length}
-                isExiting={markersExiting}
-                isClearing={isClearing}
-                isAnimated={animatedMarkers.has(annotation.id)}
-                isHovered={!markersExiting && hoveredMarkerId === annotation.id}
-                isDeleting={deletingMarkerId === annotation.id}
-                isEditingAny={!!editingAnnotation}
-                renumberFrom={renumberFrom}
-                markerClickBehavior={settings.markerClickBehavior}
-                tooltipStyle={getTooltipPosition(annotation)}
-                onHoverEnter={(a) =>
-                  !markersExiting &&
-                  a.id !== recentlyAddedIdRef.current &&
-                  handleMarkerHover(a)
-                }
-                onHoverLeave={() => handleMarkerHover(null)}
-                onClick={(a) =>
-                  settings.markerClickBehavior === "delete"
-                    ? deleteAnnotation(a.id)
-                    : startEditAnnotation(a)
-                }
-                onContextMenu={startEditAnnotation}
-              />
-            ))}
-        {markersVisible &&
-          !markersExiting &&
-          exitingAnnotationsList
-            .filter((a) => !a.isFixed)
-            .map((a) => <ExitingMarker key={a.id} annotation={a} />)}
-      </div>
-
-      {/* Fixed markers layer */}
-      <div className={styles.fixedMarkersLayer} data-feedback-toolbar>
-        {markersVisible &&
-          visibleAnnotations
-            .filter((a) => a.isFixed)
-            .map((annotation, layerIndex, arr) => (
-              <AnnotationMarker
-                key={annotation.id}
-                annotation={annotation}
-                globalIndex={visibleAnnotations.findIndex((a) => a.id === annotation.id)}
-                layerIndex={layerIndex}
-                layerSize={arr.length}
-                isExiting={markersExiting}
-                isClearing={isClearing}
-                isAnimated={animatedMarkers.has(annotation.id)}
-                isHovered={!markersExiting && hoveredMarkerId === annotation.id}
-                isDeleting={deletingMarkerId === annotation.id}
-                isEditingAny={!!editingAnnotation}
-                renumberFrom={renumberFrom}
-                markerClickBehavior={settings.markerClickBehavior}
-                tooltipStyle={getTooltipPosition(annotation)}
-                onHoverEnter={(a) =>
-                  !markersExiting &&
-                  a.id !== recentlyAddedIdRef.current &&
-                  handleMarkerHover(a)
-                }
-                onHoverLeave={() => handleMarkerHover(null)}
-                onClick={(a) =>
-                  settings.markerClickBehavior === "delete"
-                    ? deleteAnnotation(a.id)
-                    : startEditAnnotation(a)
-                }
-                onContextMenu={startEditAnnotation}
-              />
-            ))}
-        {markersVisible &&
-          !markersExiting &&
-          exitingAnnotationsList
-            .filter((a) => a.isFixed)
-            .map((a) => <ExitingMarker key={a.id} annotation={a} fixed />)}
-      </div>
-
-
-      {/* Interactive overlay */}
-      {isActive && (
-        <div
-          className={styles.overlay}
-          data-feedback-toolbar
-          style={
-            pendingAnnotation || editingAnnotation
-              ? { zIndex: 99999 }
-              : undefined
-          }
-        >
-          {/* Hover highlight */}
-          {hoverInfo?.rect &&
-            !pendingAnnotation &&
-            !isScrolling &&
-            !isDragging && (
-              <div
-                className={`${styles.hoverHighlight} ${styles.enter}`}
-                style={{
-                  left: hoverInfo.rect.left,
-                  top: hoverInfo.rect.top,
-                  width: hoverInfo.rect.width,
-                  height: hoverInfo.rect.height,
-                  borderColor: "color-mix(in srgb, var(--agentation-color-accent) 50%, transparent)",
-                  backgroundColor: "color-mix(in srgb, var(--agentation-color-accent) 4%, transparent)",
                 }}
-              />
-            )}
-
-          {/* Cmd+shift+click multi-select highlights (during selection, before releasing modifiers) */}
-          {pendingMultiSelectElements
-            .filter((item) => document.contains(item.element))
-            .map((item, index) => {
-              const rect = item.element.getBoundingClientRect();
-              // Only show green if 2+ elements selected, otherwise use default blue
-              const isMulti = pendingMultiSelectElements.length > 1;
-              return (
-                <div
-                  key={index}
-                  className={
-                    isMulti
-                      ? styles.multiSelectOutline
-                      : styles.singleSelectOutline
-                  }
-                  style={{
-                    position: "fixed",
-                    left: rect.left,
-                    top: rect.top,
-                    width: rect.width,
-                    height: rect.height,
-                    ...(isMulti
-                      ? {}
-                      : {
-                          borderColor: "color-mix(in srgb, var(--agentation-color-accent) 60%, transparent)",
-                          backgroundColor: "color-mix(in srgb, var(--agentation-color-accent) 5%, transparent)",
-                        }),
-                  }}
-                />
-              );
-            })}
-
-          {/* Marker hover outline (shows bounding box of hovered annotation) */}
-          {hoveredMarkerId &&
-            !pendingAnnotation &&
-            (() => {
-              const hoveredAnnotation = annotations.find(
-                (a) => a.id === hoveredMarkerId,
-              );
-              if (!hoveredAnnotation?.boundingBox) return null;
-
-              // Render individual element boxes if available (cmd+shift+click multi-select)
-              if (hoveredAnnotation.elementBoundingBoxes?.length) {
-                // Use live positions from hoveredTargetElements when available
-                if (hoveredTargetElements.length > 0) {
-                  return hoveredTargetElements
-                    .filter((el) => document.contains(el))
-                    .map((el, index) => {
-                      const rect = el.getBoundingClientRect();
-                      return (
-                        <div
-                          key={`hover-outline-live-${index}`}
-                          className={`${styles.multiSelectOutline} ${styles.enter}`}
-                          style={{
-                            left: rect.left,
-                            top: rect.top,
-                            width: rect.width,
-                            height: rect.height,
-                          }}
-                        />
-                      );
+                placementCount={designPlacements.length}
+                onClearPlacements={() => {
+                  // Animate placements and rearrange sections out, then clear
+                  setDesignClearSignal(n => n + 1);
+                  setRearrangeClearSignal(n => n + 1);
+                  originalSetTimeout(() => {
+                    setRearrangeState({
+                      sections: [],
+                      originalOrder: [],
+                      detectedAt: Date.now(),
                     });
-                }
-                // Fallback to stored bounding boxes
-                return hoveredAnnotation.elementBoundingBoxes.map(
-                  (bb, index) => (
-                    <div
-                      key={`hover-outline-${index}`}
-                      className={`${styles.multiSelectOutline} ${styles.enter}`}
-                      style={{
-                        left: bb.x,
-                        top: bb.y - scrollY,
-                        width: bb.width,
-                        height: bb.height,
-                      }}
-                    />
-                  ),
-                );
-              }
+                  }, 200);
+                }}
+                blankCanvas={blankCanvas}
+                onBlankCanvasChange={(on) => {
+                  const emptyRearrange = { sections: [], originalOrder: [], detectedAt: Date.now() };
+                  if (on) {
+                    // Entering wireframe: stash all explore state, restore wireframe state
+                    exploreStashRef.current = { rearrange: rearrangeState, placements: designPlacements };
+                    setRearrangeState(wireframeStashRef.current.rearrange || emptyRearrange);
+                    setDesignPlacements(wireframeStashRef.current.placements);
+                    setActiveDesignComponent(null);
+                  } else {
+                    // Leaving wireframe: stash all wireframe state, restore explore state
+                    wireframeStashRef.current = { rearrange: rearrangeState, placements: designPlacements };
+                    setRearrangeState(exploreStashRef.current.rearrange || emptyRearrange);
+                    setDesignPlacements(exploreStashRef.current.placements);
+                  }
+                  setBlankCanvas(on);
+                }}
+                wireframePurpose={wireframePurpose}
+                onWireframePurposeChange={setWireframePurpose}
+                Tooltip={HelpTooltip}
+                onDragStart={(type, e) => {
+                  e.preventDefault();
+                  const def = DEFAULT_SIZES[type];
+                  let preview: HTMLDivElement | null = null;
+                  let didDrag = false;
+                  const startX = e.clientX;
+                  const startY = e.clientY;
 
-              // Single element: use live position from hoveredTargetElement when available
-              const rect =
-                hoveredTargetElement && document.contains(hoveredTargetElement)
-                  ? hoveredTargetElement.getBoundingClientRect()
-                  : null;
+                  // Find toolbar bottom for distance-based scaling
+                  const toolbar = (e.target as HTMLElement).closest("[data-feedback-toolbar]");
+                  const toolbarTop = toolbar?.getBoundingClientRect().top ?? window.innerHeight;
 
-              const bb = rect
-                ? { x: rect.left, y: rect.top, width: rect.width, height: rect.height }
-                : {
-                    x: hoveredAnnotation.boundingBox.x,
-                    y: hoveredAnnotation.isFixed
-                      ? hoveredAnnotation.boundingBox.y
-                      : hoveredAnnotation.boundingBox.y - scrollY,
-                    width: hoveredAnnotation.boundingBox.width,
-                    height: hoveredAnnotation.boundingBox.height,
+                  const onMove = (ev: MouseEvent) => {
+                    const dx = ev.clientX - startX;
+                    const dy = ev.clientY - startY;
+
+                    if (!didDrag && (Math.abs(dx) > 4 || Math.abs(dy) > 4)) {
+                      didDrag = true;
+                      preview = document.createElement("div");
+                      preview.className = `${designStyles.dragPreview}${blankCanvas ? ` ${designStyles.dragPreviewWireframe}` : ""}`;
+                      document.body.appendChild(preview);
+                    }
+
+                    if (!preview) return;
+
+                    // Scale up as cursor moves away from toolbar
+                    const dist = Math.max(0, toolbarTop - ev.clientY);
+                    const progress = Math.min(1, dist / 180);
+                    const eased = 1 - Math.pow(1 - progress, 2); // ease-out
+
+                    const minW = 28;
+                    const minH = 20;
+                    const maxW = Math.min(140, def.width * 0.18);
+                    const maxH = Math.min(90, def.height * 0.18);
+                    const w = minW + (maxW - minW) * eased;
+                    const h = minH + (maxH - minH) * eased;
+
+                    preview.style.width = `${w}px`;
+                    preview.style.height = `${h}px`;
+                    preview.style.left = `${ev.clientX - w / 2}px`;
+                    preview.style.top = `${ev.clientY - h / 2}px`;
+                    preview.style.opacity = `${0.5 + 0.5 * eased}`;
+                    preview.textContent = eased > 0.25 ? type : "";
                   };
 
-              const isMulti = hoveredAnnotation.isMultiSelect;
-              return (
-                <div
-                  className={`${isMulti ? styles.multiSelectOutline : styles.singleSelectOutline} ${styles.enter}`}
-                  style={{
-                    left: bb.x,
-                    top: bb.y,
-                    width: bb.width,
-                    height: bb.height,
-                    ...(isMulti
-                      ? {}
-                      : {
-                          borderColor: "color-mix(in srgb, var(--agentation-color-accent) 60%, transparent)",
-                          backgroundColor: "color-mix(in srgb, var(--agentation-color-accent) 5%, transparent)",
-                        }),
-                  }}
-                />
-              );
-            })()}
+                  const onUp = (ev: MouseEvent) => {
+                    window.removeEventListener("mousemove", onMove);
+                    window.removeEventListener("mouseup", onUp);
+                    if (preview) document.body.removeChild(preview);
 
-          {/* Hover tooltip */}
-          {hoverInfo && !pendingAnnotation && !isScrolling && !isDragging && (
+                    if (didDrag) {
+                      const w = def.width;
+                      const h = def.height;
+                      const scrollY = window.scrollY;
+                      const x = Math.max(0, ev.clientX - w / 2);
+                      const y = Math.max(0, ev.clientY + scrollY - h / 2);
+                      const placement: DesignPlacement = {
+                        id: `dp-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+                        type,
+                        x,
+                        y,
+                        width: w,
+                        height: h,
+                        scrollY,
+                        timestamp: Date.now(),
+                      };
+                      setDesignPlacements((prev) => [...prev, placement]);
+                      setActiveDesignComponent(null);
+                      // Deselect any previously selected placements
+                      designSelectedIdsRef.current = new Set();
+                      setDesignDeselectSignal(n => n + 1);
+                    }
+                  };
+
+                  window.addEventListener("mousemove", onMove);
+                  window.addEventListener("mouseup", onUp);
+                }}
+              />
+
+              <SettingsPanel
+                settings={settings}
+              onSettingsChange={(patch) => setSettings((s) => ({ ...s, ...patch }))}
+                isDarkMode={isDarkMode}
+                onToggleTheme={toggleTheme}
+                isDevMode={isDevMode}
+                connectionStatus={connectionStatus}
+                endpoint={endpoint}
+                isVisible={showSettingsVisible}
+                toolbarNearBottom={!!toolbarPosition && toolbarPosition.y < 230}
+                settingsPage={settingsPage}
+                onSettingsPageChange={setSettingsPage}
+                onHideToolbar={hideToolbarTemporarily}
+              />
+            </div>
+          </div>
+
+          {/* Blank canvas backdrop — stays mounted so opacity transition works on open/close */}
+          {(isDesignMode || designOverlayExiting) && (
             <div
-              className={`${styles.hoverTooltip} ${styles.enter}`}
-              style={{
-                left: Math.max(
-                  8,
-                  Math.min(hoverPosition.x, window.innerWidth - 100),
-                ),
-                top: Math.max(
-                  hoverPosition.y - (hoverInfo.reactComponents ? 48 : 32),
-                  8,
-                ),
-              }}
-            >
-              {hoverInfo.reactComponents && (
-                <div className={styles.hoverReactPath}>
-                  {hoverInfo.reactComponents}
-                </div>
-              )}
-              <div className={styles.hoverElementName}>
-                {hoverInfo.elementName}
+              className={`${designStyles.blankCanvas} ${canvasReady ? designStyles.visible : ""} ${designInteracting ? designStyles.gridActive : ""}`}
+            style={{ '--canvas-opacity': canvasOpacity } as React.CSSProperties}
+              data-feedback-toolbar
+            />
+          )}
+
+          {/* Wireframe hint — bottom-left notice */}
+          {isDesignMode && blankCanvas && canvasReady && (
+            <div className={designStyles.wireframeNotice} data-feedback-toolbar>
+              <div className={designStyles.wireframeOpacityRow}>
+              <span className={designStyles.wireframeOpacityLabel}>Toggle Opacity</span>
+                <input
+                  type="range"
+                  className={designStyles.wireframeOpacitySlider}
+                  min={0}
+                  max={1}
+                  step={0.01}
+                  value={canvasOpacity}
+                  onChange={(e) => setCanvasOpacity(Number(e.target.value))}
+                />
               </div>
+              <div className={designStyles.wireframeNoticeTitleRow}>
+              <span className={designStyles.wireframeNoticeTitle}>Wireframe Mode</span>
+                <span className={designStyles.wireframeNoticeDivider} />
+                <button
+                  className={designStyles.wireframeStartOver}
+                  onClick={() => {
+                  setDesignClearSignal(n => n + 1);
+                  setRearrangeState({ sections: [], originalOrder: [], detectedAt: Date.now() });
+                  wireframeStashRef.current = { rearrange: null, placements: [] };
+                    setWireframePurpose("");
+                    clearWireframeState(pathname);
+                  }}
+                >
+                  Start Over
+                </button>
+              </div>
+            Drag components onto the canvas.<br />Copied output will only include the wireframed layout.
             </div>
           )}
 
-          {/* Pending annotation marker + popup */}
-          {pendingAnnotation && (
-            <>
-              {/* Show element/area outline while adding annotation */}
-              {pendingAnnotation.multiSelectElements?.length
-                ? // Cmd+shift+click multi-select: show individual boxes with live positions
-                  pendingAnnotation.multiSelectElements
-                    .filter((el) => document.contains(el))
-                    .map((el, index) => {
-                      const rect = el.getBoundingClientRect();
-                      return (
-                        <div
-                          key={`pending-multi-${index}`}
-                          className={`${styles.multiSelectOutline} ${pendingExiting ? styles.exit : styles.enter}`}
-                          style={{
-                            left: rect.left,
-                            top: rect.top,
-                            width: rect.width,
-                            height: rect.height,
-                          }}
-                        />
-                      );
-                    })
-                : // Single element or drag multi-select: show single box
-                  pendingAnnotation.targetElement &&
-                  document.contains(pendingAnnotation.targetElement)
-                    ? // Single-click: use live getBoundingClientRect for consistent positioning
-                      (() => {
-                        const rect =
-                          pendingAnnotation.targetElement!.getBoundingClientRect();
-                        return (
-                          <div
-                            className={`${styles.singleSelectOutline} ${pendingExiting ? styles.exit : styles.enter}`}
-                            style={{
-                              left: rect.left,
-                              top: rect.top,
-                              width: rect.width,
-                              height: rect.height,
-                              borderColor: "color-mix(in srgb, var(--agentation-color-accent) 60%, transparent)",
-                              backgroundColor: "color-mix(in srgb, var(--agentation-color-accent) 5%, transparent)",
-                            }}
-                          />
-                        );
-                      })()
-                    : // Drag selection or fallback: use stored boundingBox
-                      pendingAnnotation.boundingBox && (
-                        <div
-                          className={`${pendingAnnotation.isMultiSelect ? styles.multiSelectOutline : styles.singleSelectOutline} ${pendingExiting ? styles.exit : styles.enter}`}
-                          style={{
-                            left: pendingAnnotation.boundingBox.x,
-                            top: pendingAnnotation.boundingBox.y - scrollY,
-                            width: pendingAnnotation.boundingBox.width,
-                            height: pendingAnnotation.boundingBox.height,
-                            ...(pendingAnnotation.isMultiSelect
-                              ? {}
-                              : {
-                                  borderColor: "color-mix(in srgb, var(--agentation-color-accent) 60%, transparent)",
-                                  backgroundColor: "color-mix(in srgb, var(--agentation-color-accent) 5%, transparent)",
-                                }),
-                          }}
-                        />
-                      )}
-
-              {(() => {
-                // Use stored coordinates - they match what will be saved
-                const markerX = pendingAnnotation.x;
-                const markerY = pendingAnnotation.isFixed
-                  ? pendingAnnotation.y
-                  : pendingAnnotation.y - scrollY;
-
-                return (
-                  <>
-                    <PendingMarker
-                      x={markerX}
-                      y={markerY}
-                      isMultiSelect={pendingAnnotation.isMultiSelect}
-                      isExiting={pendingExiting}
-                    />
-
-                    <AnnotationPopupCSS
-                      ref={popupRef}
-                      element={pendingAnnotation.element}
-                      selectedText={pendingAnnotation.selectedText}
-                      computedStyles={pendingAnnotation.computedStylesObj}
-                      placeholder={
-                        pendingAnnotation.element === "Area selection"
-                          ? "What should change in this area?"
-                          : pendingAnnotation.isMultiSelect
-                            ? "Feedback for this group of elements..."
-                            : "What should change?"
-                      }
-                      onSubmit={addAnnotation}
-                      onCancel={cancelAnnotation}
-                      isExiting={pendingExiting}
-                      lightMode={!isDarkMode}
-                      accentColor={
-                        pendingAnnotation.isMultiSelect
-                          ? "var(--agentation-color-green)"
-                          : "var(--agentation-color-accent)"
-                      }
-                      style={{
-                        // Popup is 280px wide, centered with translateX(-50%), so 140px each side
-                        // Clamp so popup stays 20px from viewport edges
-                        left: Math.max(
-                          160,
-                          Math.min(
-                            window.innerWidth - 160,
-                            (markerX / 100) * window.innerWidth,
-                          ),
-                        ),
-                        // Position popup above or below marker to keep marker visible
-                        ...(markerY > window.innerHeight - 290
-                          ? { bottom: window.innerHeight - markerY + 20 }
-                          : { top: markerY + 20 }),
-                      }}
-                    />
-                  </>
-                );
-              })()}
-            </>
+          {/* Layout mode overlay — passthrough when no component selected */}
+          {(isDesignMode || designOverlayExiting) && (
+            <DesignMode
+              placements={designPlacements}
+              onChange={setDesignPlacements}
+              activeComponent={
+                designOverlayExiting ? null : activeDesignComponent
+              }
+              onActiveComponentChange={setActiveDesignComponent}
+              isDarkMode={isDarkMode}
+              exiting={designOverlayExiting}
+              onInteractionChange={setDesignInteracting}
+              passthrough={!activeDesignComponent}
+              extraSnapRects={rearrangeState?.sections.map((s) => s.currentRect)}
+              deselectSignal={designDeselectSignal}
+              clearSignal={designClearSignal}
+              wireframe={blankCanvas}
+              onSelectionChange={(ids, isShift) => {
+                designSelectedIdsRef.current = ids;
+                if (!isShift) {
+                  rearrangeSelectedIdsRef.current = new Set();
+                setRearrangeDeselectSignal(n => n + 1);
+                }
+              }}
+              onDragMove={(dx, dy) => {
+                // Move selected rearrange sections by same delta
+                const selIds = rearrangeSelectedIdsRef.current;
+                if (!selIds.size || !rearrangeState) return;
+                // Cache start positions on first move
+                if (!crossDragStartRef.current) {
+                  crossDragStartRef.current = new Map();
+                  for (const s of rearrangeState.sections) {
+                    if (selIds.has(s.id)) {
+                    crossDragStartRef.current.set(s.id, { x: s.currentRect.x, y: s.currentRect.y });
+                    }
+                  }
+                }
+                for (const s of rearrangeState.sections) {
+                  if (!selIds.has(s.id)) continue;
+                  const start = crossDragStartRef.current.get(s.id);
+                  if (!start) continue;
+                const outlineEl = document.querySelector(`[data-rearrange-section="${s.id}"]`) as HTMLElement | null;
+                if (outlineEl) outlineEl.style.transform = `translate(${dx}px, ${dy}px)`;
+                }
+              }}
+              onDragEnd={(dx, dy, committed) => {
+                const selIds = rearrangeSelectedIdsRef.current;
+                const starts = crossDragStartRef.current;
+                crossDragStartRef.current = null;
+                if (!selIds.size || !rearrangeState || !starts) return;
+                // Clear outline transforms
+                for (const id of selIds) {
+                const el = document.querySelector(`[data-rearrange-section="${id}"]`) as HTMLElement | null;
+                  if (el) el.style.transform = "";
+                }
+                if (committed) {
+                setRearrangeState(prev => {
+                    if (!prev) return prev;
+                    return {
+                      ...prev,
+                    sections: prev.sections.map(s => {
+                        const start = starts.get(s.id);
+                        if (!start) return s;
+                      return { ...s, currentRect: { ...s.currentRect, x: Math.max(0, start.x + dx), y: Math.max(0, start.y + dy) } };
+                      }),
+                    };
+                  });
+                }
+              }}
+            />
           )}
 
-          {/* Edit annotation popup */}
-          {editingAnnotation && (
-            <>
-              {/* Show element/area outline while editing */}
-              {editingAnnotation.elementBoundingBoxes?.length
-                ? // Cmd+shift+click: show individual element boxes (use live rects when available)
-                  (() => {
-                    // Use live positions from editingTargetElements when available
-                    if (editingTargetElements.length > 0) {
-                      return editingTargetElements
+          {/* Rearrange overlay — always active alongside design overlay */}
+          {(isDesignMode || designOverlayExiting) && rearrangeState && (
+            <RearrangeOverlay
+              rearrangeState={rearrangeState}
+              onChange={setRearrangeState}
+              isDarkMode={isDarkMode}
+              exiting={designOverlayExiting}
+              blankCanvas={blankCanvas}
+            extraSnapRects={designPlacements.map(p => ({ x: p.x, y: p.y, width: p.width, height: p.height }))}
+              clearSignal={rearrangeClearSignal}
+              deselectSignal={rearrangeDeselectSignal}
+              onSelectionChange={(ids, isShift) => {
+                rearrangeSelectedIdsRef.current = ids;
+                if (!isShift) {
+                  designSelectedIdsRef.current = new Set();
+                setDesignDeselectSignal(n => n + 1);
+                }
+              }}
+              onDragMove={(dx, dy) => {
+                // Move selected design placements by same delta
+                const selIds = designSelectedIdsRef.current;
+                if (!selIds.size) return;
+                // Cache start positions on first move
+                if (!crossDragStartRef.current) {
+                  crossDragStartRef.current = new Map();
+                  for (const p of designPlacements) {
+                    if (selIds.has(p.id)) {
+                      crossDragStartRef.current.set(p.id, { x: p.x, y: p.y });
+                    }
+                  }
+                }
+                // Imperatively move placement divs
+                for (const id of selIds) {
+                const el = document.querySelector(`[data-design-placement="${id}"]`) as HTMLElement | null;
+                  if (el) el.style.transform = `translate(${dx}px, ${dy}px)`;
+                }
+              }}
+              onDragEnd={(dx, dy, committed) => {
+                const selIds = designSelectedIdsRef.current;
+                const starts = crossDragStartRef.current;
+                crossDragStartRef.current = null;
+                if (!selIds.size || !starts) return;
+                // Clear transforms
+                for (const id of selIds) {
+                const el = document.querySelector(`[data-design-placement="${id}"]`) as HTMLElement | null;
+                  if (el) el.style.transform = "";
+                }
+                if (committed) {
+                setDesignPlacements(prev => prev.map(p => {
+                      const start = starts.get(p.id);
+                      if (!start) return p;
+                  return { ...p, x: Math.max(0, start.x + dx), y: Math.max(0, start.y + dy) };
+                }));
+                }
+              }}
+            />
+          )}
+
+          {/* Draw canvas — outside overlay so it can fade on toolbar close */}
+          <canvas
+            ref={drawCanvasRef}
+            className={`${styles.drawCanvas} ${isDrawMode ? styles.active : ""}`}
+          style={{ opacity: shouldShowMarkers ? 1 : 0, transition: "opacity 0.15s ease" }}
+            data-feedback-toolbar
+          />
+
+          {/* Markers layer - normal scrolling markers */}
+          <div className={styles.markersLayer} data-feedback-toolbar>
+            {markersVisible &&
+              visibleAnnotations
+                .filter((a) => !a.isFixed)
+                .map((annotation, layerIndex, arr) => (
+                  <AnnotationMarker
+                    key={annotation.id}
+                    annotation={annotation}
+                  globalIndex={visibleAnnotations.findIndex((a) => a.id === annotation.id)}
+                    layerIndex={layerIndex}
+                    layerSize={arr.length}
+                    isExiting={markersExiting}
+                    isClearing={isClearing}
+                    isAnimated={animatedMarkers.has(annotation.id)}
+                  isHovered={!markersExiting && hoveredMarkerId === annotation.id}
+                    isDeleting={deletingMarkerId === annotation.id}
+                    isEditingAny={!!editingAnnotation}
+                    renumberFrom={renumberFrom}
+                    markerClickBehavior={settings.markerClickBehavior}
+                    tooltipStyle={getTooltipPosition(annotation)}
+                    onHoverEnter={(a) =>
+                      !markersExiting &&
+                      a.id !== recentlyAddedIdRef.current &&
+                      handleMarkerHover(a)
+                    }
+                    onHoverLeave={() => handleMarkerHover(null)}
+                    onClick={(a) =>
+                      settings.markerClickBehavior === "delete"
+                        ? deleteAnnotation(a.id)
+                        : startEditAnnotation(a)
+                    }
+                    onContextMenu={startEditAnnotation}
+                  />
+                ))}
+            {markersVisible &&
+              !markersExiting &&
+              exitingAnnotationsList
+                .filter((a) => !a.isFixed)
+                .map((a) => <ExitingMarker key={a.id} annotation={a} />)}
+          </div>
+
+          {/* Fixed markers layer */}
+          <div className={styles.fixedMarkersLayer} data-feedback-toolbar>
+            {markersVisible &&
+              visibleAnnotations
+                .filter((a) => a.isFixed)
+                .map((annotation, layerIndex, arr) => (
+                  <AnnotationMarker
+                    key={annotation.id}
+                    annotation={annotation}
+                  globalIndex={visibleAnnotations.findIndex((a) => a.id === annotation.id)}
+                    layerIndex={layerIndex}
+                    layerSize={arr.length}
+                    isExiting={markersExiting}
+                    isClearing={isClearing}
+                    isAnimated={animatedMarkers.has(annotation.id)}
+                  isHovered={!markersExiting && hoveredMarkerId === annotation.id}
+                    isDeleting={deletingMarkerId === annotation.id}
+                    isEditingAny={!!editingAnnotation}
+                    renumberFrom={renumberFrom}
+                    markerClickBehavior={settings.markerClickBehavior}
+                    tooltipStyle={getTooltipPosition(annotation)}
+                    onHoverEnter={(a) =>
+                      !markersExiting &&
+                      a.id !== recentlyAddedIdRef.current &&
+                      handleMarkerHover(a)
+                    }
+                    onHoverLeave={() => handleMarkerHover(null)}
+                    onClick={(a) =>
+                      settings.markerClickBehavior === "delete"
+                        ? deleteAnnotation(a.id)
+                        : startEditAnnotation(a)
+                    }
+                    onContextMenu={startEditAnnotation}
+                  />
+                ))}
+            {markersVisible &&
+              !markersExiting &&
+              exitingAnnotationsList
+                .filter((a) => a.isFixed)
+                .map((a) => <ExitingMarker key={a.id} annotation={a} fixed />)}
+          </div>
+
+
+          {/* Interactive overlay */}
+          {isActive && (
+            <div
+              className={styles.overlay}
+              data-feedback-toolbar
+              style={
+                pendingAnnotation || editingAnnotation
+                  ? { zIndex: 99999 }
+                  : undefined
+              }
+            >
+              {/* Hover highlight */}
+              {hoverInfo?.rect &&
+                !pendingAnnotation &&
+                !isScrolling &&
+                !isDragging && (
+                  <div
+                    className={`${styles.hoverHighlight} ${styles.enter}`}
+                    style={{
+                      left: hoverInfo.rect.left,
+                      top: hoverInfo.rect.top,
+                      width: hoverInfo.rect.width,
+                      height: hoverInfo.rect.height,
+                    borderColor: "color-mix(in srgb, var(--agentation-color-accent) 50%, transparent)",
+                    backgroundColor: "color-mix(in srgb, var(--agentation-color-accent) 4%, transparent)",
+                    }}
+                  />
+                )}
+
+              {/* Cmd+shift+click multi-select highlights (during selection, before releasing modifiers) */}
+              {pendingMultiSelectElements
+                .filter((item) => document.contains(item.element))
+                .map((item, index) => {
+                  const rect = item.element.getBoundingClientRect();
+                  // Only show green if 2+ elements selected, otherwise use default blue
+                  const isMulti = pendingMultiSelectElements.length > 1;
+                  return (
+                    <div
+                      key={index}
+                      className={
+                        isMulti
+                          ? styles.multiSelectOutline
+                          : styles.singleSelectOutline
+                      }
+                      style={{
+                        position: "fixed",
+                        left: rect.left,
+                        top: rect.top,
+                        width: rect.width,
+                        height: rect.height,
+                        ...(isMulti
+                          ? {}
+                          : {
+                            borderColor: "color-mix(in srgb, var(--agentation-color-accent) 60%, transparent)",
+                            backgroundColor: "color-mix(in srgb, var(--agentation-color-accent) 5%, transparent)",
+                            }),
+                      }}
+                    />
+                  );
+                })}
+
+              {/* Marker hover outline (shows bounding box of hovered annotation) */}
+              {hoveredMarkerId &&
+                !pendingAnnotation &&
+                (() => {
+                  const hoveredAnnotation = annotations.find(
+                    (a) => a.id === hoveredMarkerId,
+                  );
+                  if (!hoveredAnnotation?.boundingBox) return null;
+
+                  // Render individual element boxes if available (cmd+shift+click multi-select)
+                  if (hoveredAnnotation.elementBoundingBoxes?.length) {
+                    // Use live positions from hoveredTargetElements when available
+                    if (hoveredTargetElements.length > 0) {
+                      return hoveredTargetElements
                         .filter((el) => document.contains(el))
                         .map((el, index) => {
                           const rect = el.getBoundingClientRect();
                           return (
                             <div
-                              key={`edit-multi-live-${index}`}
+                              key={`hover-outline-live-${index}`}
                               className={`${styles.multiSelectOutline} ${styles.enter}`}
                               style={{
                                 left: rect.left,
@@ -4587,10 +4374,10 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
                         });
                     }
                     // Fallback to stored bounding boxes
-                    return editingAnnotation.elementBoundingBoxes!.map(
+                    return hoveredAnnotation.elementBoundingBoxes.map(
                       (bb, index) => (
                         <div
-                          key={`edit-multi-${index}`}
+                          key={`hover-outline-${index}`}
                           className={`${styles.multiSelectOutline} ${styles.enter}`}
                           style={{
                             left: bb.x,
@@ -4601,107 +4388,337 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
                         />
                       ),
                     );
-                  })()
-                : // Single element or drag multi-select: show single box
-                  (() => {
-                    // Use live position from editingTargetElement when available
-                    const rect =
-                      editingTargetElement &&
-                      document.contains(editingTargetElement)
-                        ? editingTargetElement.getBoundingClientRect()
-                        : null;
+                  }
 
-                    const bb = rect
-                      ? { x: rect.left, y: rect.top, width: rect.width, height: rect.height }
-                      : editingAnnotation.boundingBox
-                        ? {
-                            x: editingAnnotation.boundingBox.x,
-                            y: editingAnnotation.isFixed
-                              ? editingAnnotation.boundingBox.y
-                              : editingAnnotation.boundingBox.y - scrollY,
-                            width: editingAnnotation.boundingBox.width,
-                            height: editingAnnotation.boundingBox.height,
-                          }
-                        : null;
+                  // Single element: use live position from hoveredTargetElement when available
+                  const rect =
+                  hoveredTargetElement && document.contains(hoveredTargetElement)
+                      ? hoveredTargetElement.getBoundingClientRect()
+                      : null;
 
-                    if (!bb) return null;
+                  const bb = rect
+                  ? { x: rect.left, y: rect.top, width: rect.width, height: rect.height }
+                    : {
+                        x: hoveredAnnotation.boundingBox.x,
+                        y: hoveredAnnotation.isFixed
+                          ? hoveredAnnotation.boundingBox.y
+                          : hoveredAnnotation.boundingBox.y - scrollY,
+                        width: hoveredAnnotation.boundingBox.width,
+                        height: hoveredAnnotation.boundingBox.height,
+                      };
 
-                    return (
-                      <div
-                        className={`${editingAnnotation.isMultiSelect ? styles.multiSelectOutline : styles.singleSelectOutline} ${styles.enter}`}
-                        style={{
-                          left: bb.x,
-                          top: bb.y,
-                          width: bb.width,
-                          height: bb.height,
-                          ...(editingAnnotation.isMultiSelect
-                            ? {}
-                            : {
+                  const isMulti = hoveredAnnotation.isMultiSelect;
+                  return (
+                    <div
+                      className={`${isMulti ? styles.multiSelectOutline : styles.singleSelectOutline} ${styles.enter}`}
+                      style={{
+                        left: bb.x,
+                        top: bb.y,
+                        width: bb.width,
+                        height: bb.height,
+                        ...(isMulti
+                          ? {}
+                          : {
+                            borderColor: "color-mix(in srgb, var(--agentation-color-accent) 60%, transparent)",
+                            backgroundColor: "color-mix(in srgb, var(--agentation-color-accent) 5%, transparent)",
+                            }),
+                      }}
+                    />
+                  );
+                })()}
+
+              {/* Hover tooltip */}
+              {hoverInfo && !pendingAnnotation && !isScrolling && !isDragging && (
+                <div
+                  className={`${styles.hoverTooltip} ${styles.enter}`}
+                  style={{
+                    left: Math.max(
+                      8,
+                      Math.min(hoverPosition.x, window.innerWidth - 100),
+                    ),
+                    top: Math.max(
+                      hoverPosition.y - (hoverInfo.reactComponents ? 48 : 32),
+                      8,
+                    ),
+                  }}
+                >
+                  {hoverInfo.reactComponents && (
+                    <div className={styles.hoverReactPath}>
+                      {hoverInfo.reactComponents}
+                    </div>
+                  )}
+                  <div className={styles.hoverElementName}>
+                    {hoverInfo.elementName}
+                  </div>
+                </div>
+              )}
+
+              {/* Pending annotation marker + popup */}
+              {pendingAnnotation && (
+                <>
+                  {/* Show element/area outline while adding annotation */}
+                  {pendingAnnotation.multiSelectElements?.length
+                    ? // Cmd+shift+click multi-select: show individual boxes with live positions
+                      pendingAnnotation.multiSelectElements
+                        .filter((el) => document.contains(el))
+                        .map((el, index) => {
+                          const rect = el.getBoundingClientRect();
+                          return (
+                            <div
+                              key={`pending-multi-${index}`}
+                              className={`${styles.multiSelectOutline} ${pendingExiting ? styles.exit : styles.enter}`}
+                              style={{
+                                left: rect.left,
+                                top: rect.top,
+                                width: rect.width,
+                                height: rect.height,
+                              }}
+                            />
+                          );
+                        })
+                    : // Single element or drag multi-select: show single box
+                      pendingAnnotation.targetElement &&
+                        document.contains(pendingAnnotation.targetElement)
+                      ? // Single-click: use live getBoundingClientRect for consistent positioning
+                        (() => {
+                          const rect =
+                            pendingAnnotation.targetElement!.getBoundingClientRect();
+                          return (
+                            <div
+                              className={`${styles.singleSelectOutline} ${pendingExiting ? styles.exit : styles.enter}`}
+                              style={{
+                                left: rect.left,
+                                top: rect.top,
+                                width: rect.width,
+                                height: rect.height,
                                 borderColor: "color-mix(in srgb, var(--agentation-color-accent) 60%, transparent)",
                                 backgroundColor: "color-mix(in srgb, var(--agentation-color-accent) 5%, transparent)",
-                              }),
-                        }}
-                      />
+                              }}
+                            />
+                          );
+                        })()
+                      : // Drag selection or fallback: use stored boundingBox
+                        pendingAnnotation.boundingBox && (
+                          <div
+                            className={`${pendingAnnotation.isMultiSelect ? styles.multiSelectOutline : styles.singleSelectOutline} ${pendingExiting ? styles.exit : styles.enter}`}
+                            style={{
+                              left: pendingAnnotation.boundingBox.x,
+                              top: pendingAnnotation.boundingBox.y - scrollY,
+                              width: pendingAnnotation.boundingBox.width,
+                              height: pendingAnnotation.boundingBox.height,
+                              ...(pendingAnnotation.isMultiSelect
+                                ? {}
+                                : {
+                                    borderColor: "color-mix(in srgb, var(--agentation-color-accent) 60%, transparent)",
+                                    backgroundColor: "color-mix(in srgb, var(--agentation-color-accent) 5%, transparent)",
+                                  }),
+                            }}
+                          />
+                        )}
+
+                  {(() => {
+                    // Use stored coordinates - they match what will be saved
+                    const markerX = pendingAnnotation.x;
+                    const markerY = pendingAnnotation.isFixed
+                      ? pendingAnnotation.y
+                      : pendingAnnotation.y - scrollY;
+
+                    return (
+                      <>
+                        <PendingMarker
+                          x={markerX}
+                          y={markerY}
+                          isMultiSelect={pendingAnnotation.isMultiSelect}
+                          isExiting={pendingExiting}
+                        />
+
+                        <AnnotationPopupCSS
+                          ref={popupRef}
+                          element={pendingAnnotation.element}
+                          selectedText={pendingAnnotation.selectedText}
+                          computedStyles={pendingAnnotation.computedStylesObj}
+                          placeholder={
+                            pendingAnnotation.element === "Area selection"
+                              ? "What should change in this area?"
+                              : pendingAnnotation.isMultiSelect
+                                ? "Feedback for this group of elements..."
+                                : "What should change?"
+                          }
+                          onSubmit={addAnnotation}
+                          onCancel={cancelAnnotation}
+                          isExiting={pendingExiting}
+                          lightMode={!isDarkMode}
+                          accentColor={
+                            pendingAnnotation.isMultiSelect
+                              ? "var(--agentation-color-green)"
+                              : "var(--agentation-color-accent)"
+                          }
+                          style={{
+                            // Popup is 280px wide, centered with translateX(-50%), so 140px each side
+                            // Clamp so popup stays 20px from viewport edges
+                            left: Math.max(
+                              160,
+                              Math.min(
+                                window.innerWidth - 160,
+                                (markerX / 100) * window.innerWidth,
+                              ),
+                            ),
+                            // Position popup above or below marker to keep marker visible
+                            ...(markerY > window.innerHeight - 290
+                              ? { bottom: window.innerHeight - markerY + 20 }
+                              : { top: markerY + 20 }),
+                          }}
+                        />
+                      </>
                     );
                   })()}
+                </>
+              )}
 
-              <AnnotationPopupCSS
-                ref={editPopupRef}
-                element={editingAnnotation.element}
-                selectedText={editingAnnotation.selectedText}
-                computedStyles={parseComputedStylesString(
-                  editingAnnotation.computedStyles,
-                )}
-                placeholder="Edit your feedback..."
-                initialValue={editingAnnotation.comment}
-                submitLabel="Save"
-                onSubmit={updateAnnotation}
-                onCancel={cancelEditAnnotation}
-                onDelete={() => deleteAnnotation(editingAnnotation.id)}
-                isExiting={editExiting}
-                lightMode={!isDarkMode}
-                accentColor={
-                  editingAnnotation.isMultiSelect
-                    ? "var(--agentation-color-green)"
-                    : "var(--agentation-color-accent)"
-                }
-                style={(() => {
-                  const markerY = editingAnnotation.isFixed
-                    ? editingAnnotation.y
-                    : editingAnnotation.y - scrollY;
-                  return {
-                    // Popup is 280px wide, centered with translateX(-50%), so 140px each side
-                    // Clamp so popup stays 20px from viewport edges
-                    left: Math.max(
-                      160,
-                      Math.min(
-                        window.innerWidth - 160,
-                        (editingAnnotation.x / 100) * window.innerWidth,
-                      ),
-                    ),
-                    // Position popup above or below marker to keep marker visible
-                    ...(markerY > window.innerHeight - 290
-                      ? { bottom: window.innerHeight - markerY + 20 }
-                      : { top: markerY + 20 }),
-                  };
-                })()}
-              />
-            </>
-          )}
+              {/* Edit annotation popup */}
+              {editingAnnotation && (
+                <>
+                  {/* Show element/area outline while editing */}
+                  {editingAnnotation.elementBoundingBoxes?.length
+                    ? // Cmd+shift+click: show individual element boxes (use live rects when available)
+                      (() => {
+                        // Use live positions from editingTargetElements when available
+                        if (editingTargetElements.length > 0) {
+                          return editingTargetElements
+                            .filter((el) => document.contains(el))
+                            .map((el, index) => {
+                              const rect = el.getBoundingClientRect();
+                              return (
+                                <div
+                                  key={`edit-multi-live-${index}`}
+                                  className={`${styles.multiSelectOutline} ${styles.enter}`}
+                                  style={{
+                                    left: rect.left,
+                                    top: rect.top,
+                                    width: rect.width,
+                                    height: rect.height,
+                                  }}
+                                />
+                              );
+                            });
+                        }
+                        // Fallback to stored bounding boxes
+                        return editingAnnotation.elementBoundingBoxes!.map(
+                          (bb, index) => (
+                            <div
+                              key={`edit-multi-${index}`}
+                              className={`${styles.multiSelectOutline} ${styles.enter}`}
+                              style={{
+                                left: bb.x,
+                                top: bb.y - scrollY,
+                                width: bb.width,
+                                height: bb.height,
+                              }}
+                            />
+                          ),
+                        );
+                      })()
+                    : // Single element or drag multi-select: show single box
+                      (() => {
+                        // Use live position from editingTargetElement when available
+                        const rect =
+                          editingTargetElement &&
+                          document.contains(editingTargetElement)
+                            ? editingTargetElement.getBoundingClientRect()
+                            : null;
 
-          {/* Drag selection - all visuals use refs for smooth 60fps */}
-          {isDragging && (
-            <>
-              <div ref={dragRectRef} className={styles.dragSelection} />
-              <div
-                ref={highlightsContainerRef}
-                className={styles.highlightsContainer}
-              />
-            </>
+                        const bb = rect
+                        ? { x: rect.left, y: rect.top, width: rect.width, height: rect.height }
+                          : editingAnnotation.boundingBox
+                            ? {
+                                x: editingAnnotation.boundingBox.x,
+                                y: editingAnnotation.isFixed
+                                  ? editingAnnotation.boundingBox.y
+                                  : editingAnnotation.boundingBox.y - scrollY,
+                                width: editingAnnotation.boundingBox.width,
+                                height: editingAnnotation.boundingBox.height,
+                              }
+                            : null;
+
+                        if (!bb) return null;
+
+                        return (
+                          <div
+                            className={`${editingAnnotation.isMultiSelect ? styles.multiSelectOutline : styles.singleSelectOutline} ${styles.enter}`}
+                            style={{
+                              left: bb.x,
+                              top: bb.y,
+                              width: bb.width,
+                              height: bb.height,
+                              ...(editingAnnotation.isMultiSelect
+                                ? {}
+                                : {
+                                  borderColor: "color-mix(in srgb, var(--agentation-color-accent) 60%, transparent)",
+                                  backgroundColor: "color-mix(in srgb, var(--agentation-color-accent) 5%, transparent)",
+                                  }),
+                            }}
+                          />
+                        );
+                      })()}
+
+                  <AnnotationPopupCSS
+                    ref={editPopupRef}
+                    element={editingAnnotation.element}
+                    selectedText={editingAnnotation.selectedText}
+                    computedStyles={parseComputedStylesString(
+                      editingAnnotation.computedStyles,
+                    )}
+                    placeholder="Edit your feedback..."
+                    initialValue={editingAnnotation.comment}
+                    submitLabel="Save"
+                    onSubmit={updateAnnotation}
+                    onCancel={cancelEditAnnotation}
+                    onDelete={() => deleteAnnotation(editingAnnotation.id)}
+                    isExiting={editExiting}
+                    lightMode={!isDarkMode}
+                    accentColor={
+                      editingAnnotation.isMultiSelect
+                        ? "var(--agentation-color-green)"
+                        : "var(--agentation-color-accent)"
+                    }
+                    style={(() => {
+                      const markerY = editingAnnotation.isFixed
+                        ? editingAnnotation.y
+                        : editingAnnotation.y - scrollY;
+                      return {
+                        // Popup is 280px wide, centered with translateX(-50%), so 140px each side
+                        // Clamp so popup stays 20px from viewport edges
+                        left: Math.max(
+                          160,
+                          Math.min(
+                            window.innerWidth - 160,
+                            (editingAnnotation.x / 100) * window.innerWidth,
+                          ),
+                        ),
+                        // Position popup above or below marker to keep marker visible
+                        ...(markerY > window.innerHeight - 290
+                          ? { bottom: window.innerHeight - markerY + 20 }
+                          : { top: markerY + 20 }),
+                      };
+                    })()}
+                  />
+                </>
+              )}
+
+              {/* Drag selection - all visuals use refs for smooth 60fps */}
+              {isDragging && (
+                <>
+                  <div ref={dragRectRef} className={styles.dragSelection} />
+                  <div
+                    ref={highlightsContainerRef}
+                    className={styles.highlightsContainer}
+                  />
+                </>
+              )}
+            </div>
           )}
-        </div>
-      )}
-    </div>,
+      </div>
+    </ShadowRoot>,
     document.body,
   );
 }

--- a/package/src/components/page-toolbar-css/index.tsx
+++ b/package/src/components/page-toolbar-css/index.tsx
@@ -3575,9 +3575,9 @@ export function PageFeedbackToolbarCSS({
   };
 
   return createPortal(
-    <ShadowRoot ref={portalWrapperRef} host="agentation-toolbar" style={{ display: "contents" }}>
+    <ShadowRoot host="agentation-toolbar" style={{ display: "contents" }}>
       <style>{shadowCss}{agentationColorTokensCss}</style>
-      <div style={{ display: "contents" }} data-agentation-theme={isDarkMode ? "dark" : "light"} data-agentation-accent={settings.annotationColorId} data-agentation-root="">
+      <div ref={portalWrapperRef} style={{ display: "contents" }} data-agentation-theme={isDarkMode ? "dark" : "light"} data-agentation-accent={settings.annotationColorId} data-agentation-root="">
           {/* Toolbar */}
           <div
             className={`${styles.toolbar}${userClassName ? ` ${userClassName}` : ""}`}

--- a/package/src/components/page-toolbar-css/index.tsx
+++ b/package/src/components/page-toolbar-css/index.tsx
@@ -98,6 +98,7 @@ import { css as annotationMarkerCss } from "./annotation-marker/styles.module.sc
 import { css as checkboxFieldCss } from "./settings-panel/checkbox-field/styles.module.scss";
 import { css as settingsPanelCss } from "./settings-panel/styles.module.scss";
 import { css as switchCss } from "../switch/styles.module.scss";
+import { useShadowRoot } from "../../utils/use-shadow-root";
 
 const shadowCss = [
   resetCss,
@@ -1823,7 +1824,7 @@ export function PageFeedbackToolbarCSS({
     ].join(", ");
 
     const style = document.createElement("style");
-    style.id = "feedback-cursor-styles";
+    style.id = "agentation-cursor";
     // Text elements get text cursor (higher specificity with body prefix)
     // Everything else gets crosshair
     style.textContent = `
@@ -1833,7 +1834,7 @@ export function PageFeedbackToolbarCSS({
     document.head.appendChild(style);
 
     return () => {
-      const existingStyle = document.getElementById("feedback-cursor-styles");
+      const existingStyle = document.getElementById("agentation-cursor");
       if (existingStyle) existingStyle.remove();
     };
   }, [isActive]);
@@ -3514,9 +3515,6 @@ export function PageFeedbackToolbarCSS({
     pendingMultiSelectElements,
   ]);
 
-  if (!mounted) return null;
-  if (isToolbarHidden) return null;
-
   const hasAnnotations = annotations.length > 0;
 
   // Filter annotations for rendering (exclude exiting ones from normal flow)
@@ -3573,6 +3571,11 @@ export function PageFeedbackToolbarCSS({
 
     return styles;
   };
+
+  const shadowRoot = useShadowRoot(portalWrapperRef);
+  
+  if (!mounted) return null;
+  if (isToolbarHidden) return null;
 
   return createPortal(
     <ShadowRoot host="agentation-toolbar" style={{ display: "contents" }}>
@@ -3938,7 +3941,7 @@ export function PageFeedbackToolbarCSS({
                       didDrag = true;
                       preview = document.createElement("div");
                       preview.className = `${designStyles.dragPreview}${blankCanvas ? ` ${designStyles.dragPreviewWireframe}` : ""}`;
-                      document.body.appendChild(preview);
+                      portalWrapperRef.current?.appendChild(preview);
                     }
 
                     if (!preview) return;
@@ -3966,7 +3969,7 @@ export function PageFeedbackToolbarCSS({
                   const onUp = (ev: MouseEvent) => {
                     window.removeEventListener("mousemove", onMove);
                     window.removeEventListener("mouseup", onUp);
-                    if (preview) document.body.removeChild(preview);
+                    if (preview) preview.remove();
 
                     if (didDrag) {
                       const w = def.width;
@@ -4138,7 +4141,7 @@ export function PageFeedbackToolbarCSS({
               isDarkMode={isDarkMode}
               exiting={designOverlayExiting}
               blankCanvas={blankCanvas}
-            extraSnapRects={designPlacements.map(p => ({ x: p.x, y: p.y, width: p.width, height: p.height }))}
+              extraSnapRects={designPlacements.map(p => ({ x: p.x, y: p.y, width: p.width, height: p.height }))}
               clearSignal={rearrangeClearSignal}
               deselectSignal={rearrangeDeselectSignal}
               onSelectionChange={(ids, isShift) => {

--- a/package/src/components/page-toolbar-css/settings-panel/checkbox-field/styles.module.scss
+++ b/package/src/components/page-toolbar-css/settings-panel/checkbox-field/styles.module.scss
@@ -10,6 +10,7 @@
   font-size: 13px;
   letter-spacing: -0.15px;
   color: rgb(26 26 26 / 0.5);
+  -webkit-user-select: none;
   user-select: none;
   cursor: pointer;
 

--- a/package/src/components/page-toolbar-css/settings-panel/checkbox-field/styles.module.scss
+++ b/package/src/components/page-toolbar-css/settings-panel/checkbox-field/styles.module.scss
@@ -10,6 +10,7 @@
   font-size: 13px;
   letter-spacing: -0.15px;
   color: rgb(26 26 26 / 0.5);
+  user-select: none;
   cursor: pointer;
 
   [data-agentation-theme="dark"] & {

--- a/package/src/components/page-toolbar-css/styles.module.scss
+++ b/package/src/components/page-toolbar-css/styles.module.scss
@@ -387,7 +387,6 @@
     );
   }
 
-
   &[data-error="true"] {
     color: var(--agentation-color-red);
     background-color: color-mix(
@@ -1874,122 +1873,6 @@
 
   &.settingsToggleMarginBottom {
     margin-bottom: calc(0.5rem + 6px);
-  }
-}
-
-.customCheckbox {
-  position: relative;
-  width: 14px;
-  height: 14px;
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 4px;
-  background: rgba(255, 255, 255, 0.05);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  transition:
-    background-color 0.25s ease,
-    border-color 0.25s ease;
-
-  svg {
-    color: #1a1a1a;
-    opacity: 1;
-    transition: opacity 0.15s ease;
-  }
-
-  input[type="checkbox"]:checked + & {
-    border-color: rgba(255, 255, 255, 0.3);
-    background: rgba(255, 255, 255, 1);
-  }
-
-  // Light mode variant (unchecked state)
-  [data-agentation-theme="light"] & {
-    border: 1px solid rgba(0, 0, 0, 0.15);
-    background: #fff;
-
-    // Checked state in light mode
-    &.checked {
-      border-color: #1a1a1a;
-      background: #1a1a1a;
-
-      svg {
-        color: #fff;
-      }
-    }
-  }
-}
-
-.toggleLabel {
-  font-size: 0.8125rem;
-  font-weight: 400;
-  color: rgba(255, 255, 255, 0.5);
-  letter-spacing: -0.0094em;
-  display: flex;
-  align-items: center;
-  gap: 0.25rem;
-
-  [data-agentation-theme="light"] & {
-    color: rgba(0, 0, 0, 0.5);
-  }
-}
-
-// iOS-style toggle switch
-.toggleSwitch {
-  position: relative;
-  display: inline-block;
-  width: 24px;
-  height: 16px;
-  flex-shrink: 0;
-  cursor: pointer;
-  transition:
-    background-color 0.2s cubic-bezier(0.4, 0, 0.2, 1),
-    opacity 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-
-  input {
-    opacity: 0;
-    width: 0;
-    height: 0;
-  }
-
-  input:checked + .toggleSlider {
-    background-color: var(--agentation-color-blue);
-  }
-
-  input:checked + .toggleSlider::before {
-    transform: translateX(8px);
-  }
-
-  &.disabled {
-    opacity: 0.4;
-
-    .toggleSlider {
-      cursor: not-allowed;
-    }
-  }
-}
-
-.toggleSlider {
-  position: absolute;
-  cursor: pointer;
-  inset: 0;
-  border-radius: 16px;
-  background: #484848; // Dark mode unchecked
-
-  [data-agentation-theme="light"] & {
-    background: #dddddd; // Light mode unchecked
-  }
-
-  &::before {
-    content: "";
-    position: absolute;
-    height: 12px;
-    width: 12px;
-    left: 2px;
-    bottom: 2px;
-    background: white;
-    border-radius: 50%;
-    transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
   }
 }
 

--- a/package/src/components/page-toolbar-css/styles.module.scss
+++ b/package/src/components/page-toolbar-css/styles.module.scss
@@ -202,6 +202,7 @@
 
 .toolbarContainer {
   position: relative;
+  -webkit-user-select: none;
   user-select: none;
   margin-left: auto;
   align-self: flex-end;
@@ -310,6 +311,7 @@
   position: absolute;
   top: -13px;
   right: -13px;
+  -webkit-user-select: none;
   user-select: none;
   min-width: 18px;
   height: 18px;
@@ -917,6 +919,7 @@
   box-shadow:
     0 2px 6px rgba(0, 0, 0, 0.2),
     inset 0 0 0 1px rgba(0, 0, 0, 0.04);
+  -webkit-user-select: none;
   user-select: none;
   will-change: transform, opacity;
   contain: layout style;

--- a/package/src/components/reset.scss
+++ b/package/src/components/reset.scss
@@ -1,0 +1,489 @@
+/* Reset box-model and set borders */
+/* ============================================ */
+
+*,
+::before,
+::after {
+  border-width: 0;
+  border-style: solid;
+  box-sizing: border-box;
+}
+
+/* Document */
+/* ============================================ */
+
+/**
+ * 1. Correct line height in all browsers.
+ * 2. Prevent adjustments of font size after orientation changes in iOS.
+ * 3. Remove gray overlay on links for iOS.
+ * 4. Render kerning consistently in all browsers.
+ * 5. Correct font smoothing for macOS.
+ */
+
+:host {
+  line-height: 1.5; /* 1 */
+  -webkit-text-size-adjust: 100%; /* 2 */
+  -webkit-tap-highlight-color: transparent; /* 3 */
+  font-feature-settings: "kern"; /* 4 */
+  -webkit-font-feature-settings: "kern"; /* 5 */
+  -moz-font-feature-settings: "kern"; /* 5 */
+  -webkit-font-smoothing: antialiased; /* 5 */
+  -moz-osx-font-smoothing: grayscale; /* 5 */
+}
+
+/* Vertical rhythm */
+/* ============================================ */
+
+p,
+table,
+blockquote,
+address,
+pre,
+iframe,
+form,
+figure,
+dl {
+  margin: 0;
+}
+
+/* Headings */
+/* ============================================ */
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  margin: 0;
+  font-size: inherit;
+  font-weight: inherit;
+}
+
+/* Lists (enumeration) */
+/* ============================================ */
+
+ul,
+ol,
+menu {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+/* Lists (definition) */
+/* ============================================ */
+
+dd {
+  margin-left: 0;
+}
+
+/* Grouping content */
+/* ============================================ */
+
+/**
+ * 1. Add the correct box sizing in Firefox.
+ * 2. Show the overflow in Edge and IE.
+ */
+
+hr {
+  clear: both;
+  margin: 0;
+  border-top-width: 1px;
+  height: 0; /* 1 */
+  box-sizing: content-box; /* 1 */
+  overflow: visible; /* 2 */
+  color: inherit;
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ * 3. Wrap lines by default instead of overflow.
+ */
+
+pre {
+  font-family: inherit; /* 1 */
+  font-size: inherit; /* 2 */
+  white-space: pre-line; /* 3 */
+}
+
+address {
+  font-style: inherit;
+}
+
+/* Text-level semantics */
+/* ============================================ */
+
+/**
+ * Remove the gray background on active links in IE 10.
+ */
+
+a {
+  background-color: transparent;
+  text-decoration: none;
+  color: inherit;
+}
+
+/**
+ * 1. Remove the bottom border in Chrome 57-
+ * 2. Add the correct text decoration in Chrome, Edge, IE, Opera, and Safari.
+ */
+
+abbr[title] {
+  border-bottom: none; /* 1 */
+  text-decoration: none; /* 2 */
+}
+
+/**
+ * Add the correct font weight in Chrome, Edge, and Safari.
+ */
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/**
+ * 1. Correct the inheritance and scaling of font size in all browsers.
+ * 2. Correct the odd `em` font sizing in all browsers.
+ */
+
+code,
+kbd,
+samp {
+  font-family: "Menlo", "Monaco", "Consolas", "Courier New", monospace; /* 1 */
+  font-size: inherit; /* 2 */
+}
+
+/**
+ * Add the correct font size in all browsers.
+ */
+
+small {
+  font-size: 80%;
+}
+
+/**
+ * Prevent `sub` and `sup` elements from affecting the line height in all browsers.
+ */
+
+sub,
+sup {
+  position: relative;
+  vertical-align: baseline;
+  line-height: 0;
+  font-size: 75%;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/* Replaced content */
+/* ============================================ */
+
+/**
+ * Prevent vertical alignment issues.
+ */
+
+svg,
+img,
+embed,
+object,
+iframe {
+  vertical-align: bottom;
+}
+
+/*
+ * 1. Remove image default bottom space.
+ * 2. Prevent image from overflowing the container.
+ */
+
+img {
+  display: block;
+  max-width: 100%;
+}
+
+/**
+ * Prevent alignment issues on Safari.
+ */
+
+@supports (background: -webkit-named-image(i)) {
+  svg {
+    will-change: transform;
+  }
+}
+
+/* Forms */
+/* ============================================ */
+
+/**
+ * Reset form fields to make them styleable.
+ * 1. Make form elements stylable across systems iOS especially.
+ * 2. Inherit text-transform from parent.
+ */
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  -webkit-appearance: none; /* 1 */
+  appearance: none;
+  border-radius: 0;
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  vertical-align: middle;
+  text-align: inherit;
+  text-transform: inherit; /* 2 */
+  font: inherit;
+  color: inherit;
+}
+
+/**
+ * Correct cursors for clickable elements.
+ */
+
+button,
+[type="button"],
+[type="reset"],
+[type="submit"] {
+  cursor: pointer;
+}
+
+button:disabled,
+[type="button"]:disabled,
+[type="reset"]:disabled,
+[type="submit"]:disabled {
+  cursor: default;
+}
+
+/**
+ * Clickable labels and selects.
+ */
+
+select,
+label {
+  cursor: pointer;
+}
+
+/**
+ * Improve outlines for Firefox and unify style with input elements & buttons.
+ */
+
+:-moz-focusring {
+  outline: auto;
+}
+
+select:disabled {
+  opacity: inherit;
+}
+
+/**
+ * 1. Remove padding.
+ */
+
+option {
+  padding: 0; /* 1 */
+}
+
+/**
+ * Reset to invisible
+ */
+
+fieldset {
+  margin: 0;
+  padding: 0;
+  min-width: 0;
+}
+
+legend {
+  display: contents;
+  padding: 0;
+}
+
+/**
+ * Add the correct vertical alignment in Chrome, Firefox, and Opera.
+ */
+
+progress {
+  vertical-align: baseline;
+}
+
+/**
+ * Remove the default vertical scrollbar in IE 10+.
+ */
+
+textarea {
+  overflow: auto;
+}
+
+/**
+ * Remove increment and decrement buttons in Chrome.
+ */
+
+[type="number"]::-webkit-inner-spin-button,
+[type="number"]::-webkit-outer-spin-button {
+  -webkit-appearance: none;
+}
+
+/**
+ * Correct the outline style in Safari.
+ */
+
+[type="search"] {
+  outline-offset: -2px;
+}
+
+/**
+ * Remove the inner padding in Chrome and Safari on macOS.
+ */
+
+[type="search"]::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/*
+ * Remove the ‘X’ from Chrome and Safari.
+ */
+
+[type="search"]::-webkit-search-decoration,
+[type="search"]::-webkit-search-cancel-button,
+[type="search"]::-webkit-search-results-button,
+[type="search"]::-webkit-search-results-decoration {
+  display: none;
+}
+
+/**
+ * 1. Hide file input completely.
+ * 2. Remove selected file text.
+ * 3. Set cursor to pointer for all browsers.
+ */
+
+[type="file"] {
+  opacity: 0; /* 1 */
+  font-size: 0; /* 2 */
+  cursor: pointer; /* 3 */
+}
+
+/**
+	* Fix appearance for Firefox
+	*/
+
+[type="number"] {
+  -moz-appearance: textfield;
+}
+
+/**
+ * Set cursor to pointer for all browsers.
+ */
+
+[type="range"] {
+  cursor: pointer;
+}
+
+/**
+ * Reset slider thumbs to make them styleable.
+ */
+
+[type="range"]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+[type="range"]::-moz-range-thumb {
+  -moz-appearance: none;
+  appearance: none;
+  border-width: 0;
+  border-radius: 0;
+  background-color: transparent;
+}
+
+/* Interactive */
+/* ============================================ */
+
+/*
+ * Add the correct display in Edge, IE 10+, and Firefox.
+ */
+
+details {
+  display: block;
+}
+
+/*
+ * Add the correct display in all browsers.
+ */
+
+summary {
+  display: list-item;
+}
+
+/*
+ * Remove outline for editable content.
+ */
+
+[contenteditable]:focus {
+  outline: auto;
+}
+
+/* Tables */
+/* ============================================ */
+
+/**
+1. Correct table border color inheritance in all Chrome and Safari.
+*/
+
+table {
+  border-color: inherit; /* 1 */
+  border-collapse: collapse;
+}
+
+caption {
+  text-align: left;
+}
+
+td,
+th {
+  vertical-align: top;
+  padding: 0;
+}
+
+th {
+  text-align: left;
+  font-weight: inherit;
+}
+
+/* Misc */
+/* ============================================ */
+
+/*
+ * Make placeholder style consistent across all browsers.
+ */
+
+::placeholder {
+  color: #999;
+  opacity: 1;
+}
+
+/*
+ * Hide focus outline but keep it visible for Windows High Contrast Mode.
+ */
+
+:focus {
+  outline-style: solid;
+  outline-color: transparent;
+}
+
+/*
+ * Hide input arrow when used with datalist.
+ */
+
+::-webkit-calendar-picker-indicator {
+  display: none !important;
+}

--- a/package/src/components/shadow-root/index.tsx
+++ b/package/src/components/shadow-root/index.tsx
@@ -1,0 +1,50 @@
+import {
+  useRef,
+  useState,
+  useLayoutEffect,
+  type ReactNode,
+  type ElementType,
+  type ComponentPropsWithRef,
+} from "react";
+import { createPortal } from "react-dom";
+
+export interface ShadowRootProps extends ComponentPropsWithRef<"div"> {
+  mode?: ShadowRootMode;
+  delegatesFocus?: boolean;
+  slotAssignment?: SlotAssignmentMode;
+  children?: ReactNode;
+  host?: keyof HTMLElementTagNameMap | (string & {});
+}
+
+export const ShadowRoot = ({
+  mode = "open",
+  delegatesFocus,
+  slotAssignment,
+  host = "div",
+  children,
+  ...hostProps
+}: ShadowRootProps) => {
+  const hostRef = useRef<HTMLElement>(null);
+  const [shadowContainer, setShadowContainer] = useState<HTMLDivElement | null>(
+    null,
+  );
+
+  useLayoutEffect(() => {
+    const hostElement = hostRef.current;
+    if (!hostElement || hostElement.shadowRoot) return;
+    const shadow = hostElement.attachShadow({
+      mode,
+      delegatesFocus,
+      slotAssignment,
+    });
+    setShadowContainer(shadow as unknown as HTMLDivElement);
+  }, []);
+
+  const Host = host as ElementType;
+
+  return (
+    <Host ref={hostRef} {...hostProps}>
+      {shadowContainer && createPortal(children, shadowContainer)}
+    </Host>
+  );
+};

--- a/package/src/components/switch/index.tsx
+++ b/package/src/components/switch/index.tsx
@@ -2,11 +2,25 @@ import styles from "./styles.module.scss";
 
 interface SwitchProps extends React.InputHTMLAttributes<HTMLInputElement> {}
 
-export const Switch = ({ className = "", ...props }: SwitchProps) => {
+export const Switch = ({
+  className = "",
+  checked,
+  onChange,
+  ...props
+}: SwitchProps) => {
   return (
-    <div className={`${styles.switchContainer} ${className}`}>
-      <input className={styles.switchInput} type="checkbox" {...props} />
-      <div className={styles.switchThumb}></div>
+    <div
+      className={`${styles.switchContainer} ${className}`}
+      data-checked={checked ? "" : undefined}
+    >
+      <input
+        className={styles.switchInput}
+        checked={checked}
+        onChange={onChange}
+        type="checkbox"
+        {...props}
+      />
+      <div className={styles.switchThumb} />
     </div>
   );
 };

--- a/package/src/components/switch/styles.module.scss
+++ b/package/src/components/switch/styles.module.scss
@@ -44,7 +44,7 @@
   background-color: #fff;
   transition: transform 0.15s;
 
-  .switchContainer:has(.switchInput:checked) & {
+  .switchContainer[data-checked] & {
     transform: translateX(8px);
   }
 }

--- a/package/src/scss.d.ts
+++ b/package/src/scss.d.ts
@@ -1,10 +1,12 @@
 // Type declarations for SCSS modules
 declare module "*.module.scss" {
   const classes: { [key: string]: string };
+  export const css: string;
   export default classes;
 }
 
 declare module "*.scss" {
   const content: { [key: string]: string };
+  export const css: string;
   export default content;
 }

--- a/package/src/utils/use-shadow-root.ts
+++ b/package/src/utils/use-shadow-root.ts
@@ -1,0 +1,15 @@
+import { useEffect, useState } from "react";
+
+export function useShadowRoot(ref: React.RefObject<HTMLElement>) {
+  const [shadowRoot, setShadowRoot] = useState<ShadowRoot | Document>(
+    () => (typeof document !== "undefined" ? document : null!)
+  );
+
+  useEffect(() => {
+    if (ref.current) {
+      setShadowRoot((ref.current.getRootNode() as ShadowRoot) ?? document);
+    }
+  }, []);
+
+  return shadowRoot;
+}

--- a/package/tsconfig.json
+++ b/package/tsconfig.json
@@ -17,6 +17,6 @@
     "isolatedModules": true,
     "noEmit": true
   },
-  "include": ["src"],
+  "include": ["src", "tsup.config.ts"],
   "exclude": ["node_modules", "dist"]
 }

--- a/package/tsup.config.ts
+++ b/package/tsup.config.ts
@@ -1,89 +1,51 @@
-import { defineConfig, type Options } from "tsup";
+import { defineConfig } from "tsup";
 import * as sass from "sass";
 import postcss from "postcss";
 import postcssModules from "postcss-modules";
-import * as path from "path";
 import * as fs from "fs";
 import type { Plugin } from "esbuild";
 
-// Read version from package.json at build time
 const pkg = JSON.parse(fs.readFileSync("./package.json", "utf-8"));
 const VERSION = pkg.version;
 
-// Custom SCSS CSS Modules plugin with SSR-safe style injection
-function scssModulesPlugin(): Plugin {
+const scssModulesPlugin = (): Plugin => {
   return {
     name: "scss-modules",
     setup(build) {
-      // Handle all .scss files
       build.onLoad({ filter: /\.scss$/ }, async (args) => {
         const isModule = args.path.includes(".module.");
-        // Use parent directory + filename for unique style IDs
-        const parentDir = path.basename(path.dirname(args.path));
-        const baseName = path.basename(args.path, isModule ? ".module.scss" : ".scss");
-        const styleId = `${parentDir}-${baseName}`;
+        const { css: sassOutput } = sass.compile(args.path);
 
-        // Compile SCSS to CSS
-        const result = sass.compile(args.path);
-        let css = result.css;
-
-        if (isModule) {
-          // Process with postcss-modules to get class name mappings
-          let classNames: Record<string, string> = {};
-          const postcssResult = await postcss([
-            postcssModules({
-              getJSON(cssFileName, json) {
-                classNames = json;
-              },
-              generateScopedName: "[name]__[local]___[hash:base64:5]",
-            }),
-          ]).process(css, { from: args.path });
-
-          css = postcssResult.css;
-
-          // Generate JS that exports class names and injects styles (SSR-safe)
-          const contents = `
-const css = ${JSON.stringify(css)};
-const classNames = ${JSON.stringify(classNames)};
-
-// SSR-safe style injection (always update for HMR)
-if (typeof document !== 'undefined') {
-  let style = document.getElementById('feedback-tool-styles-${styleId}');
-  if (!style) {
-    style = document.createElement('style');
-    style.id = 'feedback-tool-styles-${styleId}';
-    document.head.appendChild(style);
-  }
-  style.textContent = css;
-}
-
-export default classNames;
-`;
-          return { contents, loader: "js" };
-        } else {
-          // Regular SCSS - no CSS modules processing
-          const contents = `
-const css = ${JSON.stringify(css)};
-if (typeof document !== 'undefined') {
-  let style = document.getElementById('feedback-tool-styles-${styleId}');
-  if (!style) {
-    style = document.createElement('style');
-    style.id = 'feedback-tool-styles-${styleId}';
-    document.head.appendChild(style);
-  }
-  style.textContent = css;
-}
-export default {};
-`;
-          return { contents, loader: "js" };
+        if (!isModule) {
+          return {
+            contents: `export const css = ${JSON.stringify(sassOutput)};`,
+            loader: "js",
+          };
         }
+
+        let classNames: Record<string, string> = {};
+        const { css } = await postcss([
+          postcssModules({
+            getJSON(_, json) {
+              classNames = json;
+            },
+            generateScopedName: "[name]__[local]___[hash:base64:5]",
+          }),
+        ]).process(sassOutput, { from: args.path });
+
+        return {
+          contents: `
+            export const css = ${JSON.stringify(css)};
+            export default ${JSON.stringify(classNames)};
+          `,
+          loader: "js",
+        };
       });
     },
   };
-}
+};
 
 export default defineConfig((options) => [
-  // React component
   {
     entry: ["src/index.ts"],
     format: ["cjs", "esm"],


### PR DESCRIPTION
## Migrate toolbar to Shadow DOM for style isolation

This PR moves the toolbar into a Shadow DOM host, preventing CSS from leaking between the toolbar and the host page in either direction.

### What changed

**Shadow DOM encapsulation**
The toolbar's React tree is now rendered inside a shadow root via a new `ShadowRoot` component. All stylesheets are collected as raw CSS strings and injected as a single `<style>` tag inside the shadow root, replacing the previous approach of scattering individual `<style>` tags across `document.head`. A new `reset.scss` provides baseline normalization scoped to `:host` so host-page resets can't bleed in.

**Build pipeline refactor**
The `scssModulesPlugin` in `tsup.config.ts` has been simplified. Each SCSS file previously generated runtime code that appended style elements to `document.head` — now CSS modules export a named `css` string alongside the default class-name map, and plain `.scss` files export only a `css` string. The component concatenates these into one `<style>` tag rendered inside the shadow root. `scss.d.ts` is updated to match, and `esbuild` is now an explicit dev dependency rather than a transitive one.

**Color token CSS**
The `injectAgentationColorTokens` function that imperatively wrote to `document.head` at module load time has been replaced with a static CSS string using `:host` selectors, injected alongside the other styles inside the shadow root.

**CSS fixes for Shadow DOM compatibility**
Two `:has()` selectors that don't work reliably across shadow boundaries have been replaced with explicit `data-checked` attribute checks in `Checkbox` and `Switch`. Both components now set `data-checked` on their wrapper div and use `.container[data-checked]` in their stylesheets instead.

**Bug fixes**
- The drag preview element is appended to `portalWrapperRef.current` (inside the shadow DOM) rather than `document.body`, so it picks up shadow-scoped styles correctly
- `RearrangeOverlay` now queries its own shadow root for `[data-rearrange-section]` elements instead of `document`, preventing potential mismatches
- Cursor override styles no longer need a `:not([data-agentation-root] *)` exclusion since the toolbar is naturally isolated inside its shadow root
- `webkit-user-select: none` added throughout for Safari compatibility

**Cleanup**
Removed dead CSS from `styles.module.scss`: unused `.canvasPurpose*` blocks and `.customCheckbox`, `.toggleLabel`, `.toggleSwitch`, `.toggleSlider`, which are superseded by the `Checkbox` and `Switch` components.