### PR TITLE
Fix design-mode svg[fill="none"] leaking into host page (#181)

### DIFF
--- a/package/src/components/design-mode/styles.module.scss
+++ b/package/src/components/design-mode/styles.module.scss
@@ -2,9 +2,19 @@
 // Layout Mode Styles
 // =============================================================================
 
-// Protect stroke-based SVG icons from host page CSS overrides
-svg[fill="none"] {
-  fill: none !important;
+// Protect stroke-based SVG icons from host page CSS overrides.
+// Scoped to design-mode's own containers to avoid breaking host SVGs that use
+// fill="none" with CSS-based fills (e.g. Tailwind's fill-current).
+// See: https://github.com/benjitaylor/agentation/issues/181
+.overlay,
+.rearrangeOverlay {
+  svg[fill="none"] {
+    fill: none !important;
+  }
+
+  svg[fill="none"] :not([fill]) {
+    fill: none !important;
+  }
 }
 
 $blue: #3c82f7;


### PR DESCRIPTION
Fixes #181.

## What

Scope the `svg[fill="none"] { fill: none !important }` reset in `design-mode/styles.module.scss` under `.overlay` and `.rearrangeOverlay` instead of leaving it global.

## Why

The unscoped rule overrides host page SVGs that use `fill="none"` with CSS-based fills (Tailwind `fill-current`, Lucide icons, shadcn radio dots, etc.) — exactly the regression #58 was meant to close. #136 scoped this protection in `page-toolbar-css` and `annotation-popup-css` but missed `design-mode`, so the leak still ships in v3.0.x.

## How

Matches the existing pattern from #136 — nests the `svg[fill="none"]` (and `:not([fill])` variant) under the two top-level design-mode wrappers. Verified in the compiled `dist/index.mjs` that the rule now compiles to `.styles-module__overlay___… svg[fill=none], .styles-module__rearrangeOverlay___… svg[fill=none]`, mirroring `css5` (toolbar) and `css` (popup).

No portals are used inside design-mode, so every SVG it renders sits under one of these two containers — coverage is complete.

## How to test

1. `pnpm install && pnpm --filter agentation build`
2. `pnpm --filter agentation test` — 83 tests pass.
3. Repro from #181 (Radix RadioGroup + `<Circle className="fill-current" />`): the radio indicator renders as a filled dot again, not the empty double-ring.
4. Inspect `dist/index.mjs` → no unscoped `svg[fill=none]` selectors remain.