### PR TITLE
feat: persist sourceFile in MCP annotation store

### DIFF
--- a/mcp/src/server/mcp.ts
+++ b/mcp/src/server/mcp.ts
@@ -304,6 +304,7 @@ type Annotation = {
   timestamp?: number;
   nearbyText?: string;
   reactComponents?: string;
+  sourceFile?: string;
   status: string;
   kind?: "feedback" | "placement" | "rearrange";
   placement?: {
@@ -345,6 +346,7 @@ function mapAnnotationForMcp(a: Annotation) {
     timestamp: a.timestamp,
     nearbyText: a.nearbyText,
     reactComponents: a.reactComponents,
+    ...(a.sourceFile ? { sourceFile: a.sourceFile } : {}),
     ...(a.kind === "placement" && a.placement ? { placement: a.placement } : {}),
     ...(a.kind === "rearrange" && a.rearrange ? { rearrange: a.rearrange } : {}),
   };

--- a/mcp/src/server/sqlite.ts
+++ b/mcp/src/server/sqlite.ts
@@ -102,6 +102,7 @@ function initDatabase(db: Database.Database): void {
       is_multi_select INTEGER DEFAULT 0,
       is_fixed INTEGER DEFAULT 0,
       react_components TEXT,
+      source_file TEXT,
       url TEXT,
       intent TEXT,
       severity TEXT,
@@ -215,6 +216,7 @@ function rowToAnnotation(row: Record<string, unknown>): Annotation {
     isMultiSelect: Boolean(row.is_multi_select),
     isFixed: Boolean(row.is_fixed),
     reactComponents: row.react_components as string | undefined,
+    sourceFile: row.source_file as string | undefined,
     kind,
     ...(kind === "placement" && extra?.placement ? { placement: extra.placement } : {}),
     ...(kind === "rearrange" && extra?.rearrange ? { rearrange: extra.rearrange } : {}),
@@ -243,6 +245,7 @@ export function createSQLiteStore(dbPath?: string): AFSStore {
   // Safe migrations for new columns (no-ops if already exist)
   try { db.exec("ALTER TABLE annotations ADD COLUMN kind TEXT DEFAULT 'feedback'"); } catch {}
   try { db.exec("ALTER TABLE annotations ADD COLUMN extra TEXT"); } catch {}
+  try { db.exec("ALTER TABLE annotations ADD COLUMN source_file TEXT"); } catch {}
 
   // Restore event sequence from last event
   const lastEvent = db.prepare("SELECT MAX(sequence) as seq FROM events").get() as { seq: number | null };
@@ -269,13 +272,13 @@ export function createSQLiteStore(dbPath?: string): AFSStore {
         id, session_id, x, y, comment, element, element_path, timestamp,
         selected_text, bounding_box, nearby_text, css_classes, nearby_elements,
         computed_styles, full_path, accessibility, is_multi_select, is_fixed,
-        react_components, url, intent, severity, status, thread, created_at,
+        react_components, source_file, url, intent, severity, status, thread, created_at,
         updated_at, resolved_at, resolved_by, author_id, kind, extra
       ) VALUES (
         @id, @sessionId, @x, @y, @comment, @element, @elementPath, @timestamp,
         @selectedText, @boundingBox, @nearbyText, @cssClasses, @nearbyElements,
         @computedStyles, @fullPath, @accessibility, @isMultiSelect, @isFixed,
-        @reactComponents, @url, @intent, @severity, @status, @thread, @createdAt,
+        @reactComponents, @sourceFile, @url, @intent, @severity, @status, @thread, @createdAt,
         @updatedAt, @resolvedAt, @resolvedBy, @authorId, @kind, @extra
       )
     `),
@@ -430,6 +433,7 @@ export function createSQLiteStore(dbPath?: string): AFSStore {
         isMultiSelect: annotation.isMultiSelect ? 1 : 0,
         isFixed: annotation.isFixed ? 1 : 0,
         reactComponents: annotation.reactComponents ?? null,
+        sourceFile: annotation.sourceFile ?? null,
         url: annotation.url ?? null,
         intent: annotation.intent ?? null,
         severity: annotation.severity ?? null,
@@ -612,6 +616,7 @@ export function createTenantStore(dbPath?: string): TenantStore {
   // Safe migrations for new columns (no-ops if already exist)
   try { db.exec("ALTER TABLE annotations ADD COLUMN kind TEXT DEFAULT 'feedback'"); } catch {}
   try { db.exec("ALTER TABLE annotations ADD COLUMN extra TEXT"); } catch {}
+  try { db.exec("ALTER TABLE annotations ADD COLUMN source_file TEXT"); } catch {}
 
   // Restore event sequence from last event
   const lastEvent = db.prepare("SELECT MAX(sequence) as seq FROM events").get() as { seq: number | null };

--- a/mcp/src/types.ts
+++ b/mcp/src/types.ts
@@ -21,6 +21,7 @@ export type Annotation = {
   isMultiSelect?: boolean; // true if created via drag selection
   isFixed?: boolean; // true if element has fixed/sticky positioning (marker stays fixed)
   reactComponents?: string; // React component hierarchy (e.g. "<App> <Dashboard> <Button>")
+  sourceFile?: string; // Source file from React _debugSource (dev mode)
 
   // Annotation kind (defaults to "feedback" when undefined — backward compat)
   kind?: "feedback" | "placement" | "rearrange";

--- a/package/example/public/schema/annotation.v1.json
+++ b/package/example/public/schema/annotation.v1.json
@@ -54,6 +54,10 @@
       "type": "string",
       "description": "React component tree (e.g. \"App > Dashboard > Button\")"
     },
+    "sourceFile": {
+      "type": "string",
+      "description": "Source file path and line (e.g. \"src/Button.tsx:42\")"
+    },
     "cssClasses": {
       "type": "string",
       "description": "Element class list"

--- a/package/example/src/app/api/page.tsx
+++ b/package/example/src/app/api/page.tsx
@@ -160,6 +160,7 @@ function App() {
 
   // Context (varies by output format)
   reactComponents?: string;   // Component tree
+  sourceFile?: string;        // Source file:line ("src/Button.tsx:42")
   cssClasses?: string;
   computedStyles?: string;
   accessibility?: string;

--- a/package/example/src/app/mcp/page.tsx
+++ b/package/example/src/app/mcp/page.tsx
@@ -208,6 +208,7 @@ npx agentation-mcp help      # Show help`}
     "comment": "Button is cut off on mobile",
     "element": "button",
     "elementPath": "body > main > .hero > button.cta",
+    "sourceFile": "src/components/CTAButton.tsx:42",
     "kind": "feedback",
     "intent": "fix",
     "severity": "blocking"

--- a/package/example/src/app/schema/page.tsx
+++ b/package/example/src/app/schema/page.tsx
@@ -122,6 +122,7 @@ export default function SchemaPage() {
             code={`{
   // React-specific (when available)
   reactComponents: string;  // Component tree ("App > Dashboard > Button")
+  sourceFile: string;       // Source file:line ("src/Button.tsx:42")
 
   // Element details
   cssClasses: string;       // Class list ("btn btn-primary disabled")
@@ -209,6 +210,7 @@ export default function SchemaPage() {
 
   // Optional context
   reactComponents?: string;
+  sourceFile?: string;     // Source file:line (dev mode only)
   cssClasses?: string;
   computedStyles?: string;
   accessibility?: string;
@@ -318,6 +320,7 @@ type ThreadMessage = {
       "required": ["x", "y", "width", "height"]
     },
     "reactComponents": { "type": "string" },
+    "sourceFile": { "type": "string", "description": "Source file:line" },
     "isFixed": { "type": "boolean" },
     "isMultiSelect": { "type": "boolean" },
     "fullPath": { "type": "string" },
@@ -368,6 +371,7 @@ type ThreadMessage = {
   "url": "http://localhost:3000/landing",
   "boundingBox": { "x": 120, "y": 480, "width": 200, "height": 48 },
   "reactComponents": "App > LandingPage > HeroSection > CTAButton",
+  "sourceFile": "src/components/CTAButton.tsx:42",
   "cssClasses": "cta btn-primary",
   "nearbyText": "Get Started Free",
   "intent": "fix",


### PR DESCRIPTION
## Summary

The browser toolbar already captures `sourceFile` and sends it when syncing annotations, but the MCP server dropped it on save.
This adds `sourceFile` persistence so agents can see the source file path.

- Add `sourceFile` to the MCP `Annotation` type
- Store it in SQLite via a new `source_file` column (schema + startup migration)
- Map the field on insert and read in `rowToAnnotation`
- Expose `sourceFile` in MCP tool responses via `mapAnnotationForMcp`
- Update docs & schema

Related to #54, https://github.com/benjitaylor/agentation/commit/882a827