### PR TITLE
fix: add clipboard fallback for non-secure contexts (HTTP)

### DIFF
--- a/package/src/components/page-toolbar-css/index.tsx
+++ b/package/src/components/page-toolbar-css/index.tsx
@@ -69,6 +69,7 @@ import {
   updateAnnotation as updateAnnotationOnServer,
   deleteAnnotation as deleteAnnotationFromServer,
 } from "../../utils/sync";
+import { copyTextToClipboard } from "../../utils/clipboard";
 import { getReactComponentName } from "../../utils/react-detection";
 import {
   getSourceLocation,
@@ -3107,11 +3108,7 @@ const [settings, setSettings] = useState<ToolbarSettings>(() => {
     }
 
     if (copyToClipboard) {
-      try {
-        await navigator.clipboard.writeText(output);
-      } catch {
-        // Clipboard may fail (permissions, not HTTPS, etc.) - continue anyway
-      }
+      await copyTextToClipboard(output);
     }
 
     // Fire callback with markdown output (always, regardless of clipboard success)

--- a/package/src/utils/clipboard.ts
+++ b/package/src/utils/clipboard.ts
@@ -1,0 +1,34 @@
+/**
+ * 将文本复制到剪贴板, 优先使用现代 Clipboard API,
+ * 在非安全上下文 (HTTP, 非 localhost) 下回退到 execCommand 方案.
+ */
+export async function copyTextToClipboard(text: string): Promise<boolean> {
+  // 优先使用 Clipboard API (需要安全上下文: HTTPS 或 localhost)
+  if (navigator.clipboard && typeof navigator.clipboard.writeText === "function") {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch {
+      // 权限被拒绝或写入失败, 继续尝试回退方案
+    }
+  }
+
+  // 回退方案: 使用临时 textarea + execCommand('copy')
+  // 适用于非安全上下文 (HTTP) 或 Clipboard API 不可用的环境
+  try {
+    const textarea = document.createElement("textarea");
+    textarea.value = text;
+    textarea.style.position = "fixed";
+    textarea.style.top = "-9999px";
+    textarea.style.left = "-9999px";
+    textarea.style.opacity = "0";
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    const succeeded = document.execCommand("copy");
+    document.body.removeChild(textarea);
+    return succeeded;
+  } catch {
+    return false;
+  }
+}

--- a/package/src/utils/index.ts
+++ b/package/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from "./element-identification";
 export * from "./storage";
 export * from "./source-location";
 export * from "./sync";
+export * from "./clipboard";


### PR DESCRIPTION
## Problem

The Clipboard API (`navigator.clipboard.writeText`) is only available in [secure contexts](https://developer.mozilla.org/en-US/docs/Web/Security/Secure_Contexts) (HTTPS or `localhost`). When agentation runs over plain HTTP — e.g. a Vite dev server inside a Docker container accessed by IP — `navigator.clipboard` is `undefined` and the copy button silently fails. The UI shows the "copied" checkmark, but nothing actually reaches the clipboard.

The existing catch block swallows the error without any fallback:

```ts
if (copyToClipboard) {
  try {
    await navigator.clipboard.writeText(output);
  } catch {
    // Clipboard may fail (permissions, not HTTPS, etc.) - continue anyway
  }
}
```

## Fix

Add a `copyTextToClipboard` utility that:

1. Tries `navigator.clipboard.writeText()` first (preferred, secure contexts)
2. Falls back to a temporary `<textarea>` + `document.execCommand('copy')` when the Clipboard API is unavailable

This ensures copy works in all contexts — HTTPS, localhost, and plain HTTP.

## Testing

- All 83 existing tests pass
- Build succeeds (`tsup` CJS + ESM + types)
- No new dependencies